### PR TITLE
[WIP] Use dry-initializer

### DIFF
--- a/dry-auto_inject.gemspec
+++ b/dry-auto_inject.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'dry-initializer'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/spec/dry/auto_inject_spec.rb
+++ b/spec/dry/auto_inject_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Dry::AutoInject do
           super
         end
 
-        def initialize(args)
-          super
-          @other = args[:other]
+        def initialize(other: nil, **args)
+          super(**args)
+          @other = other
         end
       end
     end


### PR DESCRIPTION
In the interest in using dry-rb gems where appropriate, I've updated dry-auto_inject to use dry-initializer instead of generating initializers and attr readers itself.

It seems to work pretty well, but it raises one question, since dry-initialiser supports Ruby 2.0+ keyword arguments only, not older-style options hashes, while auto-inject recently had options hash injection support added by @solnic. Do we want to do the same here in dry-auto_inject, and support keyword arguments only?

@nepalez was there anything in particular behind your choice to support keyword arguments only?

Depending on the outcome of this discussion, I'll need to tweak some naming here before this PR will be ready for merge.