### PR TITLE
Support initializers with keyword args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.1
   - 2.2
   - rbx-2
-  - jruby
   - ruby-head
   - jruby-head
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,4 @@ gemspec
 
 group :tools do
   gem 'byebug', platforms: :mri
-  gem 'rubocop'
-  gem 'guard'
-  gem 'guard-rspec'
-  gem 'guard-rubocop'
 end

--- a/dry-auto_inject.gemspec
+++ b/dry-auto_inject.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/spec/dry/auto_inject_spec.rb
+++ b/spec/dry/auto_inject_spec.rb
@@ -92,4 +92,53 @@ RSpec.describe Dry::AutoInject do
       expect(grand_child_class.new(one: 1, two: 2, three: 3).foo).to eql('bar')
     end
   end
+
+  context 'with keyword args' do
+    let(:parent_class) do
+      Class.new do
+        include Test::AutoInject.kwargs[:one, :two, 'namespace.three']
+
+        attr_reader :other
+
+        def initialize(other: nil, **args)
+          super(**args)
+          @other = other
+        end
+      end
+    end
+
+    let(:child_class) do
+      Class.new(parent_class) do
+        attr_reader :foo
+
+        def initialize(**args)
+          super
+          @foo = 'bar'
+        end
+      end
+    end
+
+    let(:grand_child_class) do
+      Class.new(child_class)
+    end
+
+    let(:test_args) do
+      [
+        {}, { one: 1, two: 2, three: 3 }, { two: 2, three: 3 },
+        { one: 1, three: 3 }, { one: 1, two: 2 }, { three: 3 },
+        { one: 1 }, { one: 1, three: 3 }
+      ]
+    end
+
+    it 'works' do
+      test_args.each do |args|
+        assert_valid_object(parent_class.new(**args))
+        assert_valid_object(child_class.new(**args))
+        assert_valid_object(grand_child_class.new(**args))
+      end
+
+      expect(parent_class.new(other: true).other).to be(true)
+      expect(grand_child_class.new(one: 1, two: 2, three: 3).foo).to eql('bar')
+    end
+  end
 end


### PR DESCRIPTION
Support for kwargs is ready to go. Happy to merge if this looks OK to you.

I decided to stick with the manual initializer construction for now, especially since this we have a very specific job to do here, and also given that dry-initializer doesn't support hash initializers.

Now that we have 3 different initializer types, I think this is ready for a refactoring, but I'd like to leave that after I have a go at allowing local name aliases of the injected dependencies, which feels like the last big missing feature here (I'll be sure to at https://github.com/dry-rb/dry-auto_inject/pull/3 while doing that).