### PR TITLE
Support user-specified aliases for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - rbx-2
+  - rbx-3
   - ruby-head
   - jruby-head
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - rbx-3
+  - rbx
   - ruby-head
   - jruby-head
 env:

--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -3,8 +3,6 @@ module Dry
     DuplicateDependencyError = Class.new(StandardError)
 
     class DependencyMap
-      attr_reader :map
-
       def initialize(*dependencies)
         @map = {}
 

--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -19,13 +19,18 @@ module Dry
         end
       end
 
-      def dependencies
-        @map
+      def inspect
+        @map.inspect
       end
 
       def names
         @map.keys
       end
+
+      def to_h
+        @map.dup.to_h
+      end
+      alias_method :to_hash, :to_h
 
       private
 

--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -1,0 +1,41 @@
+module Dry
+  module AutoInject
+    DuplicateDependencyError = Class.new(StandardError)
+
+    class DependencyMap
+      attr_reader :map
+
+      def initialize(*dependencies)
+        @map = {}
+
+        dependencies = dependencies.dup
+        aliases = dependencies.last.is_a?(Hash) ? dependencies.pop : {}
+
+        dependencies.each do |identifier|
+          name = identifier.to_s.split(".").last
+          add_dependency(name, identifier)
+        end
+
+        aliases.each do |name, identifier|
+          add_dependency(name, identifier)
+        end
+      end
+
+      def dependencies
+        @map
+      end
+
+      def names
+        @map.keys
+      end
+
+      private
+
+      def add_dependency(name, identifier)
+        name = name.to_sym
+        raise DuplicateDependencyError, "name +{name}+ is already used" if @map.key?(name)
+        @map[name] = identifier
+      end
+    end
+  end
+end

--- a/lib/dry/auto_inject/injection.rb
+++ b/lib/dry/auto_inject/injection.rb
@@ -4,25 +4,22 @@ module Dry
     class Injection < Module
       InstanceMethods = Class.new(Module)
 
-      attr_reader :names
+      attr_reader :dependency_map
 
       attr_reader :container
 
       attr_reader :instance_mod
-
-      attr_reader :ivars
 
       attr_reader :options
 
       attr_reader :type
 
       # @api private
-      def initialize(names, container, options = {})
-        @names = names
+      def initialize(dependency_map, container, options = {})
+        @dependency_map = dependency_map
         @container = container
         @options = options
         @type = options.fetch(:type, :args)
-        @ivars = names.map(&:to_s).map { |s| s.split('.').last }.map(&:to_sym)
         @instance_mod = InstanceMethods.new
       end
 
@@ -68,8 +65,8 @@ module Dry
       def define_new_method_with_args(klass)
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.new(*args)
-            names = [#{names.map(&:inspect).join(', ')}]
-            deps = names.map.with_index { |_, i| args[i] || container[names[i]] }
+            names = #{dependency_map.dependencies.inspect}
+            deps = names.values.map.with_index { |identifier, i| args[i] || container[identifier] }
             super(*deps)
           end
         RUBY
@@ -79,9 +76,9 @@ module Dry
       def define_new_method_with_hash(klass)
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.new(options = {})
-            names = [#{names.map(&:inspect).join(', ')}]
-            deps = names.each_with_object({}) { |k, r|
-              r[k.to_s.split('.').last.to_sym] = options[k] || container[k]
+            names = #{dependency_map.dependencies.inspect}
+            deps = names.each_with_object({}) { |(name, identifier), obj|
+              obj[name] = options[name] || container[identifier]
             }.merge(options)
             super(deps)
           end
@@ -92,9 +89,9 @@ module Dry
       def define_new_method_with_kwargs(klass)
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.new(**args)
-            names = [#{names.map(&:inspect).join(', ')}]
-            deps = names.each_with_object({}) { |k, r|
-              r[k.to_s.split('.').last.to_sym] = args[k] || container[k]
+            names = #{dependency_map.dependencies.inspect}
+            deps = names.each_with_object({}) { |(name, identifier), obj|
+              obj[name] = args[name] || container[identifier]
             }.merge(args)
             super(**deps)
           end
@@ -124,7 +121,7 @@ module Dry
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def initialize(*args)
             super(#{super_params})
-            #{ivars.map.with_index { |name, i| "@#{name} = args[#{i}]" }.join("\n")}
+            #{dependency_map.names.map.with_index { |name, i| "@#{name} = args[#{i}]" }.join("\n")}
           end
         RUBY
         self
@@ -138,7 +135,7 @@ module Dry
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def initialize(options)
             super(#{super_params})
-            #{ivars.map { |name| "@#{name} = options[:#{name}]" }.join("\n")}
+            #{dependency_map.names.map { |name| "@#{name} = options[:#{name}]" }.join("\n")}
           end
         RUBY
         self
@@ -152,7 +149,7 @@ module Dry
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def initialize(**args)
             super(#{super_params})
-            #{ivars.map { |name| "@#{name} = args[:#{name}]" }.join("\n")}
+            #{dependency_map.names.map { |name| "@#{name} = args[:#{name}]" }.join("\n")}
           end
         RUBY
         self
@@ -161,7 +158,7 @@ module Dry
       # @api private
       def define_readers
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          attr_reader #{ivars.map { |name| ":#{name}" }.join(', ')}
+          attr_reader #{dependency_map.names.map { |name| ":#{name}" }.join(', ')}
         RUBY
         self
       end

--- a/lib/dry/auto_inject/injection.rb
+++ b/lib/dry/auto_inject/injection.rb
@@ -65,7 +65,7 @@ module Dry
       def define_new_method_with_args(klass)
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.new(*args)
-            names = #{dependency_map.dependencies.inspect}
+            names = #{dependency_map.inspect}
             deps = names.values.map.with_index { |identifier, i| args[i] || container[identifier] }
             super(*deps)
           end
@@ -76,7 +76,7 @@ module Dry
       def define_new_method_with_hash(klass)
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.new(options = {})
-            names = #{dependency_map.dependencies.inspect}
+            names = #{dependency_map.inspect}
             deps = names.each_with_object({}) { |(name, identifier), obj|
               obj[name] = options[name] || container[identifier]
             }.merge(options)
@@ -89,7 +89,7 @@ module Dry
       def define_new_method_with_kwargs(klass)
         klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.new(**args)
-            names = #{dependency_map.dependencies.inspect}
+            names = #{dependency_map.inspect}
             deps = names.each_with_object({}) { |(name, identifier), obj|
               obj[name] = args[name] || container[identifier]
             }.merge(args)

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -1,3 +1,4 @@
+require 'dry/auto_inject/dependency_map'
 require 'dry/auto_inject/injection'
 
 module Dry
@@ -23,7 +24,8 @@ module Dry
 
       # @api public
       def [](*names)
-        Injection.new(names, container, options)
+        dependencies = DependencyMap.new(*names)
+        Injection.new(dependencies, container, options)
       end
     end
   end

--- a/spec/dry/auto_inject_spec.rb
+++ b/spec/dry/auto_inject_spec.rb
@@ -50,6 +50,28 @@ RSpec.describe Dry::AutoInject do
       expect(grand_child_class.new(1, 2, 3).foo).to eql('bar')
     end
 
+    context 'aliased dependencies' do
+      def assert_valid_object(object)
+        expect(object.one).to eq 1
+        expect(object.two).to eq 2
+        expect(object.last).to eq 3
+      end
+
+      let(:parent_class) do
+        Class.new do
+          include Test::AutoInject[:one, :two, last: 'namespace.three']
+        end
+      end
+
+      it 'works' do
+        test_args.each do |args|
+          assert_valid_object(parent_class.new(*args))
+          assert_valid_object(child_class.new(*args))
+          assert_valid_object(grand_child_class.new(*args))
+        end
+      end
+    end
+
     context 'autoinject in a subclass' do
       let(:child_class) do
         Class.new(parent_class) do
@@ -174,6 +196,28 @@ RSpec.describe Dry::AutoInject do
         expect(grand_child_class.new(one: 1, two: 2, three: 3).foo).to eql('bar')
     end
 
+    context 'aliased dependencies' do
+      def assert_valid_object(object)
+        expect(object.one).to eq 1
+        expect(object.two).to eq 2
+        expect(object.last).to eq 3
+      end
+
+      let(:parent_class) do
+        Class.new do
+          include Test::AutoInject.hash[:one, :two, last: 'namespace.three']
+        end
+      end
+
+      it 'works' do
+        test_args.each do |args|
+          assert_valid_object(parent_class.new(args))
+          assert_valid_object(child_class.new(args))
+          assert_valid_object(grand_child_class.new(args))
+        end
+      end
+    end
+
     context 'autoinject in a subclass' do
       let(:child_class) do
         Class.new(parent_class) do
@@ -263,6 +307,28 @@ RSpec.describe Dry::AutoInject do
 
       expect(parent_class.new(other: true).other).to be(true)
       expect(grand_child_class.new(one: 1, two: 2, three: 3).foo).to eql('bar')
+    end
+
+    context 'aliased dependencies' do
+      def assert_valid_object(object)
+        expect(object.one).to eq 1
+        expect(object.two).to eq 2
+        expect(object.last).to eq 3
+      end
+
+      let(:parent_class) do
+        Class.new do
+          include Test::AutoInject.kwargs[:one, :two, last: 'namespace.three']
+        end
+      end
+
+      it 'works' do
+        test_args.each do |args|
+          assert_valid_object(parent_class.new(**args))
+          assert_valid_object(child_class.new(**args))
+          assert_valid_object(grand_child_class.new(**args))
+        end
+      end
     end
 
     context 'autoinject in a subclass' do

--- a/spec/unit/dependency_map_spec.rb
+++ b/spec/unit/dependency_map_spec.rb
@@ -1,0 +1,42 @@
+require "dry/auto_inject/dependency_map"
+
+RSpec.describe Dry::AutoInject::DependencyMap do
+  subject(:dependency_map) { Dry::AutoInject::DependencyMap.new(*dependencies) }
+  let(:dependencies) { ["namespace.one", "namespace.two"] }
+
+  it "registers specified dependencies" do
+    expect(dependency_map.dependencies).to eq({one: "namespace.one", two: "namespace.two"})
+  end
+
+  context "aliases" do
+    let(:dependencies) { ["namespace.one", second: "namespace.two"] }
+
+    it "registers dependencies with their specified aliases" do
+      expect(dependency_map.dependencies).to eq({one: "namespace.one", second: "namespace.two"})
+    end
+  end
+
+  context "duplicate identifiers" do
+    let(:dependencies) { ["namespace.one", "namespace.one"] }
+
+    it "raises an error" do
+      expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+    end
+  end
+
+  context "conflicts with automatically determined short names for identifiers" do
+    let(:dependencies) { ["namespace.one", "another_namespace.one"] }
+
+    it "raises an error" do
+      expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+    end
+  end
+
+  context "conflicts with provided aliases" do
+    let(:dependencies) { ["namespace.one", one: "namespace.two"] }
+
+    it "raises an error" do
+      expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+    end
+  end
+end

--- a/spec/unit/dependency_map_spec.rb
+++ b/spec/unit/dependency_map_spec.rb
@@ -1,50 +1,52 @@
 require "dry/auto_inject/dependency_map"
 
 RSpec.describe Dry::AutoInject::DependencyMap do
-  subject(:dependency_map) { Dry::AutoInject::DependencyMap.new(*dependencies) }
-  let(:dependencies) { ["namespace.one", "namespace.two"] }
+  describe "#initialize" do
+    subject(:dependency_map) { Dry::AutoInject::DependencyMap.new(*dependencies) }
+    let(:dependencies) { ["namespace.one", "namespace.two"] }
 
-  it "registers specified dependencies" do
-    expect(dependency_map.dependencies).to eq({one: "namespace.one", two: "namespace.two"})
-  end
-
-  context "aliases" do
-    let(:dependencies) { ["namespace.one", second: "namespace.two"] }
-
-    it "registers dependencies with their specified aliases" do
-      expect(dependency_map.dependencies).to eq({one: "namespace.one", second: "namespace.two"})
+    it "registers specified dependencies" do
+      expect(dependency_map.to_h).to eq({one: "namespace.one", two: "namespace.two"})
     end
-  end
 
-  context "aliases only" do
-    let(:dependencies) { [first: "namespace.one", second: "namespace.two"] }
+    context "aliases" do
+      let(:dependencies) { ["namespace.one", second: "namespace.two"] }
 
-    it "registers dependencies with their specified aliases" do
-      expect(dependency_map.dependencies).to eq({first: "namespace.one", second: "namespace.two"})
+      it "registers dependencies with their specified aliases" do
+        expect(dependency_map.to_h).to eq({one: "namespace.one", second: "namespace.two"})
+      end
     end
-  end
 
-  context "duplicate identifiers" do
-    let(:dependencies) { ["namespace.one", "namespace.one"] }
+    context "aliases only" do
+      let(:dependencies) { [first: "namespace.one", second: "namespace.two"] }
 
-    it "raises an error" do
-      expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+      it "registers dependencies with their specified aliases" do
+        expect(dependency_map.to_h).to eq({first: "namespace.one", second: "namespace.two"})
+      end
     end
-  end
 
-  context "conflicts with automatically determined short names for identifiers" do
-    let(:dependencies) { ["namespace.one", "another_namespace.one"] }
+    context "duplicate identifiers" do
+      let(:dependencies) { ["namespace.one", "namespace.one"] }
 
-    it "raises an error" do
-      expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+      it "raises an error" do
+        expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+      end
     end
-  end
 
-  context "conflicts with provided aliases" do
-    let(:dependencies) { ["namespace.one", one: "namespace.two"] }
+    context "conflicts with automatically determined short names for identifiers" do
+      let(:dependencies) { ["namespace.one", "another_namespace.one"] }
 
-    it "raises an error" do
-      expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+      it "raises an error" do
+        expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+      end
+    end
+
+    context "conflicts with provided aliases" do
+      let(:dependencies) { ["namespace.one", one: "namespace.two"] }
+
+      it "raises an error" do
+        expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+      end
     end
   end
 end

--- a/spec/unit/dependency_map_spec.rb
+++ b/spec/unit/dependency_map_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe Dry::AutoInject::DependencyMap do
     end
   end
 
+  context "aliases only" do
+    let(:dependencies) { [first: "namespace.one", second: "namespace.two"] }
+
+    it "registers dependencies with their specified aliases" do
+      expect(dependency_map.dependencies).to eq({first: "namespace.one", second: "namespace.two"})
+    end
+  end
+
   context "duplicate identifiers" do
     let(:dependencies) { ["namespace.one", "namespace.one"] }
 


### PR DESCRIPTION
This allows the dependency list passed to the Injector to have two parts:

1. Regular container identifiers, as per the existing behaviour (e.g. `"namespace.one", "namespace.two"`)
2. Followed by a hash of aliases and their full identifiers (e.g. `"namespace.one", special_alias: "namespace.two"`)

This makes the auto-inject support much more flexible, since equally named dependencies from different namespaces (e.g. `"somewhere.one"` and `"somewhere_else.one"`) can now be more easily used. It also gives the user the option to give their dependencies more meaningful names for use in the class’s local context.