### PR TITLE
Make super method detection more robust

### DIFF
--- a/lib/dry/auto_inject.rb
+++ b/lib/dry/auto_inject.rb
@@ -45,8 +45,7 @@ module Dry
   module AutoInject
     # @api private
     def self.super_method(klass, method)
-      method = klass.instance_method(method)
-      method unless method.owner.equal?(klass)
+      klass.instance_method(method)
     end
   end
 end

--- a/lib/dry/auto_inject.rb
+++ b/lib/dry/auto_inject.rb
@@ -45,7 +45,8 @@ module Dry
   module AutoInject
     # @api private
     def self.super_method(klass, method)
-      klass.instance_method(method)
+      method = klass.instance_method(method)
+      method unless method.owner.equal?(klass)
     end
   end
 end

--- a/lib/dry/auto_inject/injection.rb
+++ b/lib/dry/auto_inject/injection.rb
@@ -113,7 +113,7 @@ module Dry
       # @api private
       def define_constructor_with_args(klass)
         super_method = Dry::AutoInject.super_method(klass, :initialize)
-        super_params = if super_method.nil? || super_method.parameters.empty?
+        super_params = if super_method.parameters.empty?
           ''
         elsif super_method.parameters.any? { |type, _| type == :rest }
           '*args'
@@ -133,7 +133,7 @@ module Dry
       # @api private
       def define_constructor_with_hash(klass)
         super_method = Dry::AutoInject.super_method(klass, :initialize)
-        super_params = super_method.nil? || super_method.parameters.empty? ? '' : 'options'
+        super_params = super_method.parameters.empty? ? '' : 'options'
 
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def initialize(options)
@@ -147,7 +147,7 @@ module Dry
       # @api private
       def define_constructor_with_kwargs(klass)
         super_method = Dry::AutoInject.super_method(klass, :initialize)
-        super_params = super_method.nil? || super_method.parameters.empty? ? '' : '**args'
+        super_params = super_method.parameters.empty? ? '' : '**args'
 
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def initialize(**args)

--- a/lib/dry/auto_inject/injection.rb
+++ b/lib/dry/auto_inject/injection.rb
@@ -113,7 +113,7 @@ module Dry
       # @api private
       def define_constructor_with_args(klass)
         super_method = Dry::AutoInject.super_method(klass, :initialize)
-        super_params = if super_method.parameters.empty?
+        super_params = if super_method.nil? || super_method.parameters.empty?
           ''
         elsif super_method.parameters.any? { |type, _| type == :rest }
           '*args'
@@ -133,7 +133,7 @@ module Dry
       # @api private
       def define_constructor_with_hash(klass)
         super_method = Dry::AutoInject.super_method(klass, :initialize)
-        super_params = super_method.parameters.empty? ? '' : 'options'
+        super_params = super_method.nil? || super_method.parameters.empty? ? '' : 'options'
 
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def initialize(options)
@@ -147,7 +147,7 @@ module Dry
       # @api private
       def define_constructor_with_kwargs(klass)
         super_method = Dry::AutoInject.super_method(klass, :initialize)
-        super_params = super_method.parameters.empty? ? '' : '**args'
+        super_params = super_method.nil? || super_method.parameters.empty? ? '' : '**args'
 
         instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def initialize(**args)

--- a/spec/integration/inheritance_spec.rb
+++ b/spec/integration/inheritance_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Inheritance" do
 
     it "passes dependencies to the initializer" do
       # This example only works on more modern Ruby version (2.1 and newer)
-      return unless Class.instance_methods.include?(:include)
+      skip unless Class.instance_methods.include?(:include)
 
       class_with_initializer.include Test::AutoInject[:one]
       expect(class_with_initializer.new.one).to eq 1

--- a/spec/integration/inheritance_spec.rb
+++ b/spec/integration/inheritance_spec.rb
@@ -1,21 +1,27 @@
 RSpec.describe "Inheritance" do
-  let(:container) { { one: 1, two: 2, 'namespace.three' => 3 } }
-  let(:auto_inject) { Dry::AutoInject(container) }
+  before do
+    module Test
+      AutoInject = Dry::AutoInject({one: 1, two: 2, 'namespace.three' => 3})
+    end
+  end
 
-  context "auto-inject included from outside a class with an existing initializer" do
+  context "auto-inject included from outside a class with an existing initializer to manage ivar assignment" do
     let(:class_with_initializer) do
       Class.new do
-        attr_reader :foo
+        attr_reader :one
 
-        def initialize(foo)
-          @foo = foo
+        def initialize(one)
+          @one = one
         end
       end
     end
 
     it "passes dependencies to the initializer" do
-      class_with_initializer.send :include, auto_inject[:one]
-      expect(class_with_initializer.new.foo).to eq 1
+      # This example only works on more modern Ruby version (2.1 and newer)
+      return unless Class.instance_methods.include?(:include)
+
+      class_with_initializer.include Test::AutoInject[:one]
+      expect(class_with_initializer.new.one).to eq 1
     end
   end
 end

--- a/spec/integration/inheritance_spec.rb
+++ b/spec/integration/inheritance_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "Inheritance" do
+  let(:container) { { one: 1, two: 2, 'namespace.three' => 3 } }
+  let(:auto_inject) { Dry::AutoInject(container) }
+
+  context "auto-inject included from outside a class with an existing initializer" do
+    let(:class_with_initializer) do
+      Class.new do
+        attr_reader :foo
+
+        def initialize(foo)
+          @foo = foo
+        end
+      end
+    end
+
+    it "passes dependencies to the initializer" do
+      class_with_initializer.include(auto_inject[:one])
+      expect(class_with_initializer.new.foo).to eq 1
+    end
+  end
+end

--- a/spec/integration/inheritance_spec.rb
+++ b/spec/integration/inheritance_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Inheritance" do
     end
 
     it "passes dependencies to the initializer" do
-      class_with_initializer.include(auto_inject[:one])
+      class_with_initializer.send :include, auto_inject[:one]
       expect(class_with_initializer.new.foo).to eq 1
     end
   end


### PR DESCRIPTION
Allow it to work when a class already has an initialize method defined, so the auto-injected dependencies can be passed straight to it.

Resolves #9