### PR TITLE
Handle args injection properly when super initializers take `*` args

### DIFF
--- a/lib/dry/auto_inject/injection.rb
+++ b/lib/dry/auto_inject/injection.rb
@@ -110,6 +110,12 @@ module Dry
       # @api private
       def define_constructor_with_args(klass)
         super_method = Dry::AutoInject.super_method(klass, :initialize)
+
+        # Look upwards past `def initialize(*)` methods until we get an explicit list of parameters
+        while super_method && super_method.parameters == [[:rest]]
+          super_method = Dry::AutoInject.super_method(super_method.owner, :initialize)
+        end
+
         super_params = if super_method.nil? || super_method.parameters.empty?
           ''
         elsif super_method.parameters.any? { |type, _| type == :rest }

--- a/spec/integration/args_injection_spec.rb
+++ b/spec/integration/args_injection_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe "argument parameters" do
+  describe "inheritance" do
+    describe "module included with an initialize accepting anonymous splat and passing all args through to super (which accepts no args)" do
+      before do
+        module Test
+          AutoInject = Dry::AutoInject({one: 1})
+
+          module PassThroughInitializer
+            attr_reader :module_var
+
+            def initialize(*)
+              super
+              @module_var = "hi"
+            end
+          end
+        end
+      end
+
+      let(:including_class) do
+        Class.new do
+          include Test::PassThroughInitializer
+          include Test::AutoInject[:one]
+        end
+      end
+
+      it "works" do
+        instance = including_class.new
+
+        expect(instance.one).to eq 1
+        expect(instance.module_var).to eq "hi"
+      end
+    end
+  end
+end


### PR DESCRIPTION
When determine what args to pass to super, super methods like `initialize(*)` don't actually convey enough useful information to us. With a method like this, there's no way to actually _use_ the args, so you'd only ever do it if you intend to call `super` inside it and just pass all args to the super without modifying them. So when we see cases like this, we now continue to run upwards through super `#initialize` methods until we find one with a proper args list (or none at all). This ensures we actually pass the appropriate args upwards to super from our generated `#initialize`.

Fixes #12 

/cc @flash-gordon I fixed your bug report, just not in the way you suggested, since that broke other cases to do with class inheritance.