### PR TITLE
Provide explicit initialize arguments if super method doesn’t take any

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
 matrix:
   allow_failures:
+    - rvm: rbx
     - rvm: ruby-head
     - rvm: jruby-head
 notifications:

--- a/spec/dry/auto_inject_spec.rb
+++ b/spec/dry/auto_inject_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe Dry::AutoInject do
           Class.new do
             attr_reader :other
 
-            def initialize(other:)
+            def initialize(other: nil)
               @other = other
             end
           end

--- a/spec/dry/auto_inject_spec.rb
+++ b/spec/dry/auto_inject_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe Dry::AutoInject do
       expect(grand_child_class.new(1, 2, 3).foo).to eql('bar')
     end
 
+    it 'raises an argument error when non-specific args are passed to the initializer' do
+      expect { parent_class.new(nil, nil, nil, 'unexpected') }.to raise_error ArgumentError
+    end
+
     context 'aliased dependencies' do
       def assert_valid_object(object)
         expect(object.one).to eq 1
@@ -356,7 +360,19 @@ RSpec.describe Dry::AutoInject do
       expect(grand_child_class.new(one: 1, two: 2, three: 3).foo).to eql('bar')
     end
 
+    it 'raise an argument error when non-specified keywords are passed to initializer' do
+      expect { parent_class.new(unexpected: 'foo') }.to raise_error ArgumentError
+    end
+
     context 'aliased dependencies' do
+      let(:test_args) do
+        [
+          {}, { one: 1, two: 2, last: 3 }, { two: 2, last: 3 },
+          { one: 1, last: 3 }, { one: 1, two: 2 }, { last: 3 },
+          { one: 1 }, { one: 1, last: 3 }
+        ]
+      end
+
       def assert_valid_object(object)
         expect(object.one).to eq 1
         expect(object.two).to eq 2
@@ -402,6 +418,27 @@ RSpec.describe Dry::AutoInject do
 
             assert_valid_object(child_instance)
             expect(child_instance.first).to eq 1
+          end
+        end
+      end
+
+      context 'superclass initialize accepts keywords args outside the injected dependencies list' do
+        let(:parent_class) do
+          Class.new do
+            attr_reader :other
+
+            def initialize(other:)
+              @other = other
+            end
+          end
+        end
+
+        it 'works' do
+          test_args.each do |args|
+            child_instance = child_class.new(other: 'other', **args)
+
+            assert_valid_object(child_instance)
+            expect(child_instance.other).to eq 'other'
           end
         end
       end


### PR DESCRIPTION
This returns better feedback (an ArgumentError exception) if the user provides an unknown argument.

Resolves #16