### PR TITLE
fixes typo 'AutoInect' -> 'AutoInject'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     These strategies can be accessed via methods on the main builder object:
 
     ```ruby
-    MyInject = Dry::AutoInect(my_container)
+    MyInject = Dry::AutoInject(my_container)
 
     class MyClass
       include MyInject.hash["my_dep"]
@@ -59,7 +59,7 @@
     These aliases enable you to specify your own name for dependencies, both for their local readers and their keys in the kwargs- and hash-based initializers. Specify aliases by passing a hash of names:
 
     ```ruby
-    MyInject = Dry::AutoInect(my_container)
+    MyInject = Dry::AutoInject(my_container)
 
     class MyClass
       include MyInject[my_dep: "some_other.dep"]


### PR DESCRIPTION
Thank you very much for your great work! I found a small, but important to fix, typo in changelog, so here's my patch ^_^