### PR TITLE
Add support for namespace separators

### DIFF
--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -1,5 +1,6 @@
 require 'dry/auto_inject/strategies'
 require 'dry/auto_inject/injector'
+require 'dry/auto_inject/namespace_detector'
 
 module Dry
   module AutoInject
@@ -8,16 +9,20 @@ module Dry
       attr_reader :container
 
       # @api private
+      attr_reader :namespace_separator
+
+      # @api private
       attr_reader :strategies
 
       def initialize(container, options = {})
         @container = container
+        @namespace_separator = NamespaceDetector.new(container, options[:namespace_separator]).separator
         @strategies = options.fetch(:strategies) { Strategies }
 
         strategies.keys.each do |strategy_name|
           define_singleton_method(strategy_name) do
             strategy = strategies[strategy_name]
-            Injector.new(container, strategy)
+            Injector.new(container, namespace_separator, strategy)
           end
         end
       end

--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -3,14 +3,17 @@ module Dry
     DuplicateDependencyError = Class.new(StandardError)
 
     class DependencyMap
-      def initialize(*dependencies)
+      attr_reader :namespace_separator
+
+      def initialize(namespace_separator, *dependencies)
+        @namespace_separator = namespace_separator
         @map = {}
 
         dependencies = dependencies.dup
         aliases = dependencies.last.is_a?(Hash) ? dependencies.pop : {}
 
         dependencies.each do |identifier|
-          name = identifier.to_s.split(".").last
+          name = identifier.to_s.split(namespace_separator).last
           add_dependency(name, identifier)
         end
 

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -7,16 +7,20 @@ module Dry
       attr_reader :container
 
       # @api private
+      attr_reader :namespace_separator
+
+      # @api private
       attr_reader :strategy
 
       # @api private
-      def initialize(container, strategy)
+      def initialize(container, namespace_separator, strategy)
         @container = container
+        @namespace_separator = namespace_separator
         @strategy = strategy
       end
 
       def [](*dependency_names)
-        strategy.new(container, *dependency_names)
+        strategy.new(container, namespace_separator, *dependency_names)
       end
     end
   end

--- a/lib/dry/auto_inject/namespace_detector.rb
+++ b/lib/dry/auto_inject/namespace_detector.rb
@@ -1,0 +1,42 @@
+module Dry
+  module AutoInject
+    # Detects information about namespaces within a container.
+    class NamespaceDetector
+      DEFAULT_SEPARATOR = '.'.freeze
+
+      # Instantiates a namespace detector for a container.
+      #
+      # @param container [Dry::Container, Hash]
+      # @param separator [String] The namespace separator.
+      def initialize(container, separator = nil)
+        @container = container
+        @separator = separator if separator
+      end
+
+      # The namespace separactor for the container.
+      #
+      # @api public
+      # @return [String]
+      def separator
+        @separator ||= detect_separator
+      end
+
+      private
+
+      # @api private
+      attr_reader :container
+
+      # Detects the namespace separator from the container.
+      #
+      # @api private
+      # @return [String] The namespace separator.
+      def detect_separator
+        if container.respond_to?(:config) && container.config.respond_to?(:namespace_separator)
+          container.config.namespace_separator
+        else
+          DEFAULT_SEPARATOR
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/auto_inject/strategies/constructor.rb
+++ b/lib/dry/auto_inject/strategies/constructor.rb
@@ -17,10 +17,12 @@ module Dry
         attr_reader :dependency_map
         attr_reader :instance_mod
         attr_reader :class_mod
+        attr_reader :namespace_separator
 
-        def initialize(container, *dependency_names)
+        def initialize(container, namespace_separator, *dependency_names)
           @container = container
-          @dependency_map = DependencyMap.new(*dependency_names)
+          @namespace_separator = namespace_separator
+          @dependency_map = DependencyMap.new(namespace_separator, *dependency_names)
           @instance_mod = InstanceMethods.new
           @class_mod = ClassMethods.new(container)
         end

--- a/spec/integration/namespace_separator_spec.rb
+++ b/spec/integration/namespace_separator_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe "Namespace separator" do
+  context "when using a dry-container" do
+    before do
+      module ContainerWithStars
+        extend Dry::Container::Mixin
+      end
+      ContainerWithStars.configure do |config|
+        config.namespace_separator = '*'
+      end
+      ContainerWithStars.register(:one, -> { 1 })
+      ContainerWithStars.register(:two, -> { 2 })
+      ContainerWithStars.namespace('namespace') do
+        register('three', -> { 3 })
+      end
+
+      module NamespacesWithDryContainer
+        Inject = Dry::AutoInject(ContainerWithStars)
+      end
+    end
+
+    let(:test_class) do
+      Class.new do
+        include NamespacesWithDryContainer::Inject[:one, :two, 'namespace*three']
+      end
+    end
+
+    it 'uses the container namespace separator' do
+      instance = test_class.new
+
+      expect(instance.one).to eq 1
+      expect(instance.two).to eq 2
+      expect(instance.three).to eq 3
+    end
+  end
+
+  context "when using an option to specify" do
+    before do
+      module NamespacesWithOption
+        Inject = Dry::AutoInject(
+          {one: 1, two: 2, 'namespace*three' => 3},
+          {namespace_separator: '*'}
+        )
+      end
+    end
+
+    let(:test_class) do
+      Class.new do
+        include NamespacesWithOption::Inject[:one, :two, 'namespace*three']
+      end
+    end
+
+    it 'uses the specified namespace separator' do
+      instance = test_class.new
+
+      expect(instance.one).to eq 1
+      expect(instance.two).to eq 2
+      expect(instance.three).to eq 3
+    end
+  end
+
+  context "when unspecified" do
+    before do
+      module NamespacesWithDefault
+        Inject = Dry::AutoInject({one: 1, two: 2, 'namespace.three' => 3})
+      end
+    end
+
+    let(:test_class) do
+      Class.new do
+        include NamespacesWithDefault::Inject[:one, :two, 'namespace.three']
+      end
+    end
+
+    it 'defaults to "." for a namespace separator' do
+      instance = test_class.new
+
+      expect(instance.one).to eq 1
+      expect(instance.two).to eq 2
+      expect(instance.three).to eq 3
+    end
+  end
+end

--- a/spec/unit/dependency_map_spec.rb
+++ b/spec/unit/dependency_map_spec.rb
@@ -2,7 +2,7 @@ require "dry/auto_inject/dependency_map"
 
 RSpec.describe Dry::AutoInject::DependencyMap do
   describe "#initialize" do
-    subject(:dependency_map) { Dry::AutoInject::DependencyMap.new(*dependencies) }
+    subject(:dependency_map) { Dry::AutoInject::DependencyMap.new('.', *dependencies) }
     let(:dependencies) { ["namespace.one", "namespace.two"] }
 
     it "registers specified dependencies" do


### PR DESCRIPTION
This adds the ability to specify the namespace separator, to allow for
dry-container's configurable namespace separators. It performs some
introspection on the container to determine what the namespace separator
should be.

It's not hard-coded to dry-container since you _can_ pass in a
`:namespace_separator` option into the Builder that is then passed along
the chain. This value will actually override the value that is detected
from the container.

There are two main things that I don't like about this approach:
- There isn't a great interface for querying a dry-container for its
  namespace separator. Thus, we have to dig into the container's
  `#config` property to get at it. That feels subpar to me because we're
  "defining" a container as something with a `#config` that has a
  specific attribute instead of asking the container directly.
- Since the namespace separator has to be specified up front, we have to
  pass it along several layers that don't care about it. It becomes
  cruft in the initializers. One solution to this would be to build a
  configuration object that gets passed through the layers, but that
  still doesn't seem great. Any ideas?
