### PR TITLE
Support strategy chaining

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
--r ./spec/spec_helper.rb
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ bundler_args: --without console
 script:
   - bundle exec rake spec
 rvm:
-  - 2.0
   - 2.1
   - 2.2
+  - 2.3
   - rbx
   - ruby-head
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
 rvm:
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.1
   - rbx
   - ruby-head
   - jruby-head

--- a/dry-auto_inject.gemspec
+++ b/dry-auto_inject.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_runtime_dependency 'dry-container', '~> 0.3.4'
 

--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -17,7 +17,7 @@ module Dry
         strategies.keys.each do |strategy_name|
           define_singleton_method(strategy_name) do
             strategy = strategies[strategy_name]
-            Injector.new(container, strategy)
+            Injector.new(container, strategy, builder: self)
           end
         end
       end

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -2,7 +2,7 @@ require 'dry/auto_inject/strategies'
 
 module Dry
   module AutoInject
-    class Injector
+    class Injector < BasicObject
       # @api private
       attr_reader :container
 
@@ -10,13 +10,21 @@ module Dry
       attr_reader :strategy
 
       # @api private
-      def initialize(container, strategy)
+      attr_reader :builder
+
+      # @api private
+      def initialize(container, strategy, builder:)
         @container = container
         @strategy = strategy
+        @builder = builder
       end
 
       def [](*dependency_names)
         strategy.new(container, *dependency_names)
+      end
+
+      def method_missing(name, *args, &block)
+        builder.send(name)
       end
     end
   end

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -24,7 +24,7 @@ module Dry
       end
 
       def respond_to?(name, include_private = false)
-        name == :[] || builder.respond_to?(name)
+        Injector.instance_methods.include?(name) || builder.respond_to?(name)
       end
 
       private

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -23,12 +23,14 @@ module Dry
         strategy.new(container, *dependency_names)
       end
 
-      def method_missing(name, *args, &block)
-        builder.public_send(name)
-      end
-
       def respond_to?(name, include_private = false)
         name == :[] || builder.respond_to?(name)
+      end
+
+      private
+
+      def method_missing(name, *args, &block)
+        builder.public_send(name)
       end
     end
   end

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -24,7 +24,7 @@ module Dry
       end
 
       def method_missing(name, *args, &block)
-        builder.send(name)
+        builder.public_send(name)
       end
     end
   end

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -28,7 +28,7 @@ module Dry
       end
 
       def respond_to?(name, include_private = false)
-        name == :[] || builder.respond_to?(name, include_private)
+        name == :[] || builder.respond_to?(name)
       end
     end
   end

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -26,6 +26,10 @@ module Dry
       def method_missing(name, *args, &block)
         builder.public_send(name)
       end
+
+      def respond_to?(name, include_private = false)
+        name == :[] || builder.respond_to?(name, include_private)
+      end
     end
   end
 end

--- a/spec/integration/chaining_injectors_spec.rb
+++ b/spec/integration/chaining_injectors_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe "chaining injectors" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject({one: 1, two: 2})
+    end
+  end
+
+  let(:class_with_inject) {
+    Class.new do
+      include Test::AutoInject.args.kwargs[:one, :two]
+    end
+  }
+
+  it "supports chaining injectors" do
+    object = class_with_inject.new
+    expect(object.one).to eq 1
+    expect(object.two).to eq 2
+
+    object = class_with_inject.new(one: "one", two: "two")
+    expect(object.one).to eq "one"
+    expect(object.two).to eq "two"
+  end
+end


### PR DESCRIPTION
This makes it possible when using dry-auto_inject to set up a default injector strategy, but switch to a different strategy on a case-by-case basis.

This is what we've already made possible for dry-component's `Container#injector`, now also possible for anyone working with dry-auto_inject directly.