### PR TITLE
Use a BasicObject with method_missing for the builder API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - rvm: rbx
     - rvm: ruby-head
     - rvm: jruby-head
+addons:
+  code_climate:
+    repo_token: 029b5aa100b82b6710e285597b7eabe760357b5dd1f626514371356055378d8c
 notifications:
   email: false
   webhooks:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in dry-container.gemspec
 gemspec
 
+group :test do
+  gem "codeclimate-test-reporter", require: nil
+end
+
 group :tools do
   gem 'byebug', platforms: :mri
   gem 'pry'

--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -15,19 +15,23 @@ module Dry
         @strategies = options.fetch(:strategies) { Strategies }
       end
 
-      def method_missing(name, *args, &block)
-        return super unless strategies.key?(name)
-
-        Injector.new(container, strategies[name])
+      # @api public
+      def [](*dependency_names)
+        default[*dependency_names]
       end
 
       def respond_to?(name, include_private = false)
         name == :[] || strategies.key?(name)
       end
 
-      # @api public
-      def [](*dependency_names)
-        default[*dependency_names]
+      private
+
+      def method_missing(name, *args, &block)
+        if strategies.key?(name)
+          Injector.new(container, strategies[name])
+        else
+          super
+        end
       end
     end
   end

--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -21,7 +21,7 @@ module Dry
       end
 
       def respond_to?(name, include_private = false)
-        name == :[] || strategies.key?(name)
+        Builder.public_instance_methods.include?(name) || strategies.key?(name)
       end
 
       private

--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -28,7 +28,7 @@ module Dry
 
       def method_missing(name, *args, &block)
         if strategies.key?(name)
-          Injector.new(container, strategies[name])
+          Injector.new(container, strategies[name], builder: self)
         else
           super
         end

--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -3,7 +3,7 @@ require 'dry/auto_inject/injector'
 
 module Dry
   module AutoInject
-    class Builder
+    class Builder < BasicObject
       # @api private
       attr_reader :container
 
@@ -13,13 +13,16 @@ module Dry
       def initialize(container, options = {})
         @container = container
         @strategies = options.fetch(:strategies) { Strategies }
+      end
 
-        strategies.keys.each do |strategy_name|
-          define_singleton_method(strategy_name) do
-            strategy = strategies[strategy_name]
-            Injector.new(container, strategy)
-          end
-        end
+      def method_missing(name, *args, &block)
+        return super unless strategies.key?(name)
+
+        Injector.new(container, strategies[name])
+      end
+
+      def respond_to?(name, include_private = false)
+        name == :[] || strategies.key?(name)
       end
 
       # @api public

--- a/lib/dry/auto_inject/injector.rb
+++ b/lib/dry/auto_inject/injector.rb
@@ -30,7 +30,7 @@ module Dry
       private
 
       def method_missing(name, *args, &block)
-        builder.public_send(name)
+        builder.__send__(name)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,18 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'dry-auto_inject'
+if RUBY_ENGINE == "ruby"
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
+
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
+end
 
 begin
   require 'byebug'
 rescue LoadError; end
+
+require 'dry-auto_inject'
 
 module Test
   def self.remove_constants

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -1,0 +1,25 @@
+require "dry/auto_inject/builder"
+
+RSpec.describe Dry::AutoInject::Builder do
+  describe "#respond_to?" do
+    subject(:builder) { Dry::AutoInject::Builder.new({}, strategies: {kwargs: Object.new}) }
+
+    it "responds to strategy names" do
+      expect(builder.respond_to?(:kwargs)).to be true
+    end
+
+    it "responds to #[] as a shortcut to the default strategy" do
+      expect(builder.respond_to?(:[])).to be true
+    end
+
+    it "does not respond to unknown strategy names" do
+      expect(builder.respond_to?(:args)).to be false
+    end
+
+    %i[container strategies].each do |reader|
+      it "responds to the #{reader} attr reader" do
+        expect(builder.respond_to?(reader)).to be true
+      end
+    end
+  end
+end

--- a/spec/unit/injector_spec.rb
+++ b/spec/unit/injector_spec.rb
@@ -1,0 +1,27 @@
+require "dry/auto_inject/injector"
+
+RSpec.describe Dry::AutoInject::Builder do
+  describe "#respond_to?" do
+    subject(:injector) { Dry::AutoInject::Injector.new({}, double("strategy"), builder: builder) }
+
+    let(:builder) { Dry::AutoInject::Builder.new({}, strategies: {kwargs: double("strategy")}) }
+
+    it "responds to #[] as the main injection method" do
+      expect(injector.respond_to?(:[])).to be true
+    end
+
+    it "responds to the builder's strategy names" do
+      expect(injector.respond_to?(:kwargs)).to be true
+    end
+
+    it "does not respond to unknown strategy names" do
+      expect(injector.respond_to?(:args)).to be false
+    end
+
+    %i[container strategy builder].each do |reader|
+      it "responds to the #{reader} attr reader" do
+        expect(injector.respond_to?(reader)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using define_singleton_method was bad because interferes with Ruby’s method caching.

I want to call out how I used `respond_to?` here. Because `Builder` is a `BasicObject` subclass now, and because `BasicObject` does not even implement `#respond_to?`, I just implemented that directly and therefore didn't have to bother with `#respond_to_missing?`.
