### PR TITLE
Retain access to injector’s container when defining `.new` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Fixed
+
+- Fixed issue where multiple injectors with different containers could not be used at different classes in an inheritance hierarchy (timriley in [#31](https://github.com/dry-rb/dry-auto_inject/pull/31))
+
 # 0.4.0 / 2016-07-26
 
 ### Added

--- a/lib/dry/auto_inject/strategies/args.rb
+++ b/lib/dry/auto_inject/strategies/args.rb
@@ -7,7 +7,7 @@ module Dry
       class Args < Constructor
         private
 
-        def define_new(klass)
+        def define_new
           class_mod.class_exec(container, dependency_map) do |container, dependency_map|
             define_method :new do |*args|
               deps = dependency_map.to_h.values.map.with_index { |identifier, i|

--- a/lib/dry/auto_inject/strategies/args.rb
+++ b/lib/dry/auto_inject/strategies/args.rb
@@ -8,13 +8,15 @@ module Dry
         private
 
         def define_new(klass)
-          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def self.new(*args)
-              names = #{dependency_map.inspect}
-              deps = names.values.map.with_index { |identifier, i| args[i] || container[identifier] }
+          class_mod.class_exec(container, dependency_map) do |container, dependency_map|
+            define_method :new do |*args|
+              deps = dependency_map.to_h.values.map.with_index { |identifier, i|
+                args[i] || container[identifier]
+              }
+
               super(*deps, *args[deps.size..-1])
             end
-          RUBY
+          end
         end
 
         def define_initialize(klass)

--- a/lib/dry/auto_inject/strategies/constructor.rb
+++ b/lib/dry/auto_inject/strategies/constructor.rb
@@ -29,7 +29,7 @@ module Dry
         def included(klass)
           define_readers
 
-          define_new(klass)
+          define_new
           define_initialize(klass)
 
           klass.send(:include, instance_mod)
@@ -47,7 +47,7 @@ module Dry
           self
         end
 
-        def define_new(klass)
+        def define_new
           raise NotImplementedError, "must be implemented by a subclass"
         end
 

--- a/lib/dry/auto_inject/strategies/constructor.rb
+++ b/lib/dry/auto_inject/strategies/constructor.rb
@@ -4,13 +4,7 @@ module Dry
   module AutoInject
     class Strategies
       class Constructor < Module
-        ClassMethods = Class.new(Module) do
-          def initialize(container)
-            super()
-            define_method(:container) { container }
-          end
-        end
-
+        ClassMethods = Class.new(Module)
         InstanceMethods = Class.new(Module)
 
         attr_reader :container
@@ -22,7 +16,7 @@ module Dry
           @container = container
           @dependency_map = DependencyMap.new(*dependency_names)
           @instance_mod = InstanceMethods.new
-          @class_mod = ClassMethods.new(container)
+          @class_mod = ClassMethods.new
         end
 
         # @api private

--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -7,7 +7,7 @@ module Dry
       class Hash < Constructor
         private
 
-        def define_new(_klass)
+        def define_new
           class_mod.class_exec(container, dependency_map) do |container, dependency_map|
             define_method :new do |options = {}|
               deps = dependency_map.to_h.each_with_object({}) { |(name, identifier), obj|

--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -8,15 +8,15 @@ module Dry
         private
 
         def define_new(_klass)
-          class_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def new(options = {})
-              names = #{dependency_map.inspect}
-              deps = names.each_with_object({}) { |(name, identifier), obj|
+          class_mod.class_exec(container, dependency_map) do |container, dependency_map|
+            define_method :new do |options = {}|
+              deps = dependency_map.to_h.each_with_object({}) { |(name, identifier), obj|
                 obj[name] = options[name] || container[identifier]
               }.merge(options)
+
               super(deps)
             end
-          RUBY
+          end
         end
 
         def define_initialize(klass)

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -8,15 +8,15 @@ module Dry
         private
 
         def define_new(_klass)
-          class_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def new(**args)
-              names = #{dependency_map.inspect}
-              deps = names.each_with_object({}) { |(name, identifier), obj|
+          class_mod.class_exec(container, dependency_map) do |container, dependency_map|
+            define_method :new do |**args|
+              deps = dependency_map.to_h.each_with_object({}) { |(name, identifier), obj|
                 obj[name] = args[name] || container[identifier]
               }.merge(args)
+
               super(**deps)
             end
-          RUBY
+          end
         end
 
         def define_initialize(klass)

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -7,7 +7,7 @@ module Dry
       class Kwargs < Constructor
         private
 
-        def define_new(_klass)
+        def define_new
           class_mod.class_exec(container, dependency_map) do |container, dependency_map|
             define_method :new do |**args|
               deps = dependency_map.to_h.each_with_object({}) { |(name, identifier), obj|

--- a/spec/integration/inheritance_spec.rb
+++ b/spec/integration/inheritance_spec.rb
@@ -24,4 +24,32 @@ RSpec.describe "Inheritance" do
       expect(class_with_initializer.new.one).to eq 1
     end
   end
+
+  context "injectors for different containers in inherited classes" do
+    before do
+      module Test
+        InjectOne = Dry::AutoInject(one: "hi from one")
+        InjectTwo = Dry::AutoInject(two: "hi from two")
+
+        class One
+          include InjectOne[:one]
+        end
+
+        class Two < One
+          include InjectTwo[:two]
+        end
+      end
+    end
+
+    it "uses the dependencies from each of the containers" do
+      instance = Test::Two.new
+      expect(instance.one).to eq "hi from one"
+      expect(instance.two).to eq "hi from two"
+    end
+
+    it "allows either dependency to be overridden" do
+      expect(Test::Two.new(one: "manual one").one).to eq "manual one"
+      expect(Test::Two.new(two: "manual two").two).to eq "manual two"
+    end
+  end
 end


### PR DESCRIPTION
This allows multiple injectors in various superclasses, using different containers, to continue to provide their expected dependencies when an instance of a subclass is initialized.

Resolves #30, enabling this to work as you'd expect:

```ruby
container_one = {"one" => "hi from one"}
container_two = {"two" => "hi from two"}

InjectOne = Dry::AutoInject(container_one).kwargs
InjectTwo = Dry::AutoInject(container_two).kwargs

class One
  include InjectOne["one"]
end

class Two < One
  include InjectTwo["two"]
end

Two.new
# => #<Two:0x007fa667cfd950 @one="hi from one", @two="hi from two">
```

Previously, `@one` was `nil` because the reference to `InjectOne`'s generated `.new` method container was just looking to whatever container was associated with the last mixed-in injector (i.e. `container_two` in this example).

@flash-gordon – I'm touching on some of the stuff that you tidied up last, does this seem OK to you?