### PR TITLE
Adds support for custom namespace delimiters

### DIFF
--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -1,7 +1,8 @@
 module Dry
   module AutoInject
     DuplicateDependencyError = Class.new(StandardError)
-    DependencyNameIsNotValid = Class.new(StandardError)
+    DependencyNameInvalid = Class.new(StandardError)
+
     VALID_NAME = /([a-z_][a-zA-Z_0-9]*)$/.freeze
 
     class DependencyMap
@@ -38,7 +39,7 @@ module Dry
 
       def name_for(identifier)
         matched = VALID_NAME.match(identifier.to_s)
-        raise DependencyNameIsNotValid, "#{identifier} is not a valid Ruby identifier" unless matched
+        raise DependencyNameInvalid, "name +#{identifier}+ is not a valid Ruby identifier" unless matched
         matched[0]
       end
 

--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -1,6 +1,8 @@
 module Dry
   module AutoInject
     DuplicateDependencyError = Class.new(StandardError)
+    DependencyNameIsNotValid = Class.new(StandardError)
+    VALID_NAME = /([a-z_][a-zA-Z_0-9]*)$/.freeze
 
     class DependencyMap
       def initialize(*dependencies)
@@ -10,7 +12,7 @@ module Dry
         aliases = dependencies.last.is_a?(Hash) ? dependencies.pop : {}
 
         dependencies.each do |identifier|
-          name = identifier.to_s.split(".").last
+          name = name_for(identifier)
           add_dependency(name, identifier)
         end
 
@@ -33,6 +35,12 @@ module Dry
       alias_method :to_hash, :to_h
 
       private
+
+      def name_for(identifier)
+        matched = VALID_NAME.match(identifier.to_s)
+        raise DependencyNameIsNotValid, "#{identifier} is not a valid Ruby identifier" unless matched
+        matched[0]
+      end
 
       def add_dependency(name, identifier)
         name = name.to_sym

--- a/spec/unit/dependency_map_spec.rb
+++ b/spec/unit/dependency_map_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Dry::AutoInject::DependencyMap do
       let(:dependencies) { ["3213/32132"] }
 
       it "raises an error" do
-        expect { dependency_map }.to raise_error(Dry::AutoInject::DependencyNameIsNotValid)
+        expect { dependency_map }.to raise_error(Dry::AutoInject::DependencyNameInvalid)
       end
     end
   end

--- a/spec/unit/dependency_map_spec.rb
+++ b/spec/unit/dependency_map_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe Dry::AutoInject::DependencyMap do
       end
     end
 
+    context "special delimiters for namespaces" do
+      context "slash delimiters" do
+        let(:dependencies) { ["namespace/one", "namespace/two"] }
+
+        it "registers dependencies with their specified aliases" do
+          expect(dependency_map.to_h).to eq({one: "namespace/one", two: "namespace/two"})
+        end
+      end
+
+      context "uniq delimiter for each dependency" do
+        let(:dependencies) { ["namespace/one", "namespace!two"] }
+
+        it "registers dependencies with their specified aliases" do
+          expect(dependency_map.to_h).to eq({one: "namespace/one", two: "namespace!two"})
+        end
+      end
+    end
+
     context "conflicts with automatically determined short names for identifiers" do
       let(:dependencies) { ["namespace.one", "another_namespace.one"] }
 
@@ -46,6 +64,14 @@ RSpec.describe Dry::AutoInject::DependencyMap do
 
       it "raises an error" do
         expect { dependency_map }.to raise_error(Dry::AutoInject::DuplicateDependencyError)
+      end
+    end
+
+    context "name found, but is not a valid Ruby identifier" do
+      let(:dependencies) { ["3213/32132"] }
+
+      it "raises an error" do
+        expect { dependency_map }.to raise_error(Dry::AutoInject::DependencyNameIsNotValid)
       end
     end
   end


### PR DESCRIPTION
I've decided to get back to namespace delimiters topic. My solution is extremely straightforward, but one small detail makes me nervous. Why we've been splitting string and taking last element? We always need just one last identifier, so it would be simpler to just cut it out of string. I did this.

One thing I don't like about this solution is that it gives you too much freedom (to write 643826%$&^/my_dependency). But dealing with this is not the responsibility of dependency mapper, so leave it now.