### PR TITLE
Improved handling of kwargs being passed to #initialize’s super method

### DIFF
--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -58,7 +58,11 @@ module Dry
                 end
               }
 
-              super(*args, **super_kwargs)
+              if super_kwargs.any?
+                super(*args, **super_kwargs)
+              else
+                super(*args)
+              end
 
               dependency_map.names.each do |name|
                 instance_variable_set :"@#{name}", kwargs[name]

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -9,16 +9,14 @@ module Dry
 
         def define_new
           class_mod.class_exec(container, dependency_map) do |container, dependency_map|
+            map = dependency_map.to_h.to_a
+
             define_method :new do |*args, **kwargs|
-              deps = dependency_map.to_h.each_with_object({}) { |(name, identifier), obj|
-                obj[name] = kwargs[name] || container[identifier]
-              }.merge(kwargs)
+              map.each do |name, identifier|
+                kwargs[name] ||= container[identifier]
+              end
 
-              other_kwargs = kwargs.each_with_object({}) { |(key, val), hsh|
-                hsh[key] = val unless deps.key?(key)
-              }
-
-              super(*args, **other_kwargs, **deps)
+              super(*args, **kwargs)
             end
           end
         end

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -42,6 +42,7 @@ module Dry
               #{dependency_map.names.map { |name| "@#{name} = #{name}" }.join("\n")}
             end
           RUBY
+
           self
         end
 

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -34,7 +34,7 @@ module Dry
         end
 
         def define_initialize_with_keywords
-          initialize_params = dependency_map.names.map { |name| "#{name}: nil" }.join(', ')
+          initialize_params = dependency_map.names.map { |name| "#{name}: nil" }.join(", ")
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(#{initialize_params})
@@ -50,22 +50,21 @@ module Dry
             names << name if [:key, :keyreq].include?(type)
           }
 
-          instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def initialize(*args, **kwargs)
-              dependency_names = [#{dependency_map.names.map { |name| ":#{name}" }.join(", ")}]
-              super_kwarg_names = [#{super_kwarg_names.map { |name| ":#{name}" }.join(", ")}]
-
-              super_kwargs = kwargs.each_with_object({}) { |(key, val), hsh|
-                if !dependency_names.include?(key) || super_kwarg_names.include?(key)
+          instance_mod.class_exec(dependency_map) do |dependency_map|
+            define_method :initialize do |*args, **kwargs|
+              super_kwargs = kwargs.each_with_object({}) { |(key, _), hsh|
+                if !dependency_map.names.include?(key) || super_kwarg_names.include?(key)
                   hsh[key] = kwargs[key]
                 end
               }
 
               super(*args, **super_kwargs)
 
-              #{dependency_map.names.map { |name| "@#{name} = kwargs[:#{name}]" }.join("\n")}
+              dependency_map.names.each do |name|
+                instance_variable_set :"@#{name}", kwargs[name]
+              end
             end
-          RUBY
+          end
 
           self
         end

--- a/spec/integration/args_injection_spec.rb
+++ b/spec/integration/args_injection_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "argument parameters" do
             attr_reader :module_var
 
             def initialize(*)
-              super
+              super()
               @module_var = "hi"
             end
           end

--- a/spec/integration/args_injection_spec.rb
+++ b/spec/integration/args_injection_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe "argument parameters" do
     describe "module included with an initialize accepting anonymous splat and passing all args through to super (which accepts no args)" do
       before do
         module Test
-          AutoInject = Dry::AutoInject({one: 1})
+          AutoInject = Dry::AutoInject({one: 1}).args
 
           module PassThroughInitializer
             attr_reader :module_var
 
             def initialize(*)
-              super()
+              super
               @module_var = "hi"
             end
           end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "kwargs / super #initialize method" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject({one: "dep 1"})
+    end
+  end
+
+  describe "super #initialize accepts *args and extracts keyword args manually" do
+    let(:parent_class) {
+      Class.new do
+        attr_reader :data
+
+        def initialize(*args)
+          kwargs = args.last
+          @data = kwargs.fetch(:data)
+        end
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[:one]
+      end
+    }
+
+    it "passes non-dependency keyword args to the super method" do
+      instance = child_class.new(data: "data")
+
+      expect(instance.data).to eq "data"
+      expect(instance.one).to eq "dep 1"
+    end
+  end
+end


### PR DESCRIPTION
This PR adjusts the `kwargs` injection strategy, and takes a more explicit approach to determining which kwargs should be passed to `#initialize`'s super method for classes with an injector mixed in.

Before, we'd pass kwargs up to the super method according to these two rules:

1. Pass individual kwargs if they're named keyword arg on the super method
2. Pass _all_ kwargs if the super method contains a "keyrest" `**double_splat` arg

This cased problems with one particular use case: injecting extra dependencies into rom-rb `Changeset` objects, whose `#initialize` methods have a `#parameters` signature of `[[:rest, :args]]` (i.e. `*args`). rom-rb changesets extract keyword args via different means than named method parameters. The end result was that the `*args` parameter on the changeset initialize method meant that critical keywords args (like `__data__:`) were never being passed up to the changeset's own `#initialize` when we included an auto-injection mixin.

To handle this situation, I changed the handling of passing kwargs up to the super method to follow these rules:

1. If the keyword arg is not a named dependency (i.e. if its a keyword arg we're not explicitly dealing with for auto-injection), pass it up
2. If the super method has it as an explicitly named argument (even if it's also a dependency for auto-injection), pass it up too

Rule (1) above is what allows everything to get up to the rom-rb changeset `#initialize` as it should. Rule (2) is important for ensuring we still keep general compatibility with the broadest possible set of of keyword arg initializers.

This change passed all tests except for one. And the change I had to make there seemed eminently sensible to me (the previous behaviour didn't really make sense IMO).

What do you think, @solnic, @flash-gordon?