### PR TITLE
Remove redundant freeze of regexp

### DIFF
--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -3,7 +3,7 @@ module Dry
     DuplicateDependencyError = Class.new(StandardError)
     DependencyNameInvalid = Class.new(StandardError)
 
-    VALID_NAME = /([a-z_][a-zA-Z_0-9]*)$/.freeze
+    VALID_NAME = /([a-z_][a-zA-Z_0-9]*)$/
 
     class DependencyMap
       def initialize(*dependencies)


### PR DESCRIPTION
As rubocop said - "do not freeze immutable objects as freezing them has no effect", which makes sense. There is a little reason to freeze regexp literals, it just clutters the code and may confuse a reader.