### PR TITLE
Set dependency ivars before call to super in generated #initialize methods

### DIFF
--- a/lib/dry/auto_inject/strategies/args.rb
+++ b/lib/dry/auto_inject/strategies/args.rb
@@ -36,8 +36,8 @@ module Dry
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(#{initialize_args})
-              super()
               #{dependency_map.names.map { |name| "@#{name} = #{name}" }.join("\n")}
+              super()
             end
           RUBY
         end
@@ -51,8 +51,8 @@ module Dry
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(*args)
-              super(#{super_params})
               #{dependency_map.names.map.with_index { |name, i| "@#{name} = args[#{i}]" }.join("\n")}
+              super(#{super_params})
             end
           RUBY
         end

--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -27,8 +27,8 @@ module Dry
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(options)
-              super(#{super_params})
               #{dependency_map.names.map { |name| "@#{name} = options[:#{name}]" }.join("\n")}
+              super(#{super_params})
             end
           RUBY
         end

--- a/spec/integration/args/super_initialize_spec.rb
+++ b/spec/integration/args/super_initialize_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe "args / super #initialize method" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject(one: "dep 1")
+    end
+  end
+
+  describe "super #initialize using on dependencies set in the child class" do
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject.args[:one]
+      end
+    }
+
+    context "super #initialize without parameters" do
+      let(:parent_class) {
+        Class.new do
+          attr_reader :excited_one
+
+          def initialize
+            @excited_one = "#{one}!"
+          end
+        end
+      }
+
+      it "sets the dependencies in the generated #initialize before calling super" do
+        expect(child_class.new.excited_one).to eq "dep 1!"
+      end
+    end
+
+    context "super #initiailze with parameters" do
+      let(:parent_class) {
+        Class.new do
+          attr_reader :excited_one
+
+          def initialize(one)
+            @excited_one = "#{one}!"
+          end
+        end
+      }
+
+      it "sets the dependenceies in the generated #initialize before caling super" do
+        expect(child_class.new.excited_one).to eq "dep 1!"
+      end
+    end
+  end
+end

--- a/spec/integration/hash/super_initialize_spec.rb
+++ b/spec/integration/hash/super_initialize_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe "hash / super #initialize method" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject(one: "dep 1")
+    end
+  end
+
+  describe "super #initialize using on dependencies set in the child class" do
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject.hash[:one]
+      end
+    }
+
+    context "super #initialize without parameters" do
+      let(:parent_class) {
+        Class.new do
+          attr_reader :excited_one
+
+          def initialize
+            @excited_one = "#{one}!"
+          end
+        end
+      }
+
+      it "sets the dependencies in the generated #initialize before calling super" do
+        expect(child_class.new.excited_one).to eq "dep 1!"
+      end
+    end
+
+    context "super #initiailze with parameters" do
+      let(:parent_class) {
+        Class.new do
+          attr_reader :excited_one
+
+          def initialize(options = {})
+            @excited_one = "#{one}!"
+            @two = options.fetch(:two)
+          end
+        end
+      }
+
+      it "sets the dependenceies in the generated #initialize before caling super" do
+        expect(child_class.new(two: "_").excited_one).to eq "dep 1!"
+      end
+    end
+  end
+end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -3,7 +3,54 @@
 RSpec.describe "kwargs / super #initialize method" do
   before do
     module Test
-      AutoInject = Dry::AutoInject({one: "dep 1"})
+      AutoInject = Dry::AutoInject(one: "dep 1")
+    end
+  end
+
+  describe "super #initialize using dependencies set in the child class" do
+    context "super #initialize without parameters" do
+      let(:parent_class) {
+        Class.new do
+          attr_reader :excited_one
+
+          def initialize
+            @excited_one = "#{one}!"
+          end
+        end
+      }
+
+      let(:child_class) {
+        Class.new(parent_class) do
+          include Test::AutoInject[:one]
+        end
+      }
+
+      it "sets the dependencies in the generated #initialize before calling super" do
+        expect(child_class.new.excited_one).to eq "dep 1!"
+      end
+    end
+
+    context "super #initialize with parameters" do
+      let(:parent_class) {
+        Class.new do
+          attr_reader :excited_one
+
+          def initialize(two:)
+            @excited_one = "#{one}!"
+            @two = two
+          end
+        end
+      }
+
+      let(:child_class) {
+        Class.new(parent_class) do
+          include Test::AutoInject[:one]
+        end
+      }
+
+      it "sets the dependenceies in the generated #initialize before caling super" do
+        expect(child_class.new(two: "_").excited_one).to eq "dep 1!"
+      end
     end
   end
 


### PR DESCRIPTION
This makes the library support a wider variety of class hierarchies. In some cases, `#initialize` from another application or library class may need access to the dependencies provided by auto-injection in a subclass. This change makes sure those dependencies are set before the call to the superclass’ `#initialize`.