### PR TITLE
Only assign nil values in initialize if ivar not previously defined

### DIFF
--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -27,7 +27,7 @@ module Dry
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(options)
-              #{dependency_map.names.map { |name| "@#{name} = options[:#{name}]" }.join("\n")}
+              #{dependency_map.names.map { |name| "@#{name} = options[:#{name}] unless !options.key?(#{name}) && instance_variable_defined?(:'@#{name}')" }.join("\n")}
               super(#{super_params})
             end
           RUBY

--- a/spec/integration/hash/inheritance/existing_ivars_before_initialize_spec.rb
+++ b/spec/integration/hash/inheritance/existing_ivars_before_initialize_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe "kwargs / inheritance / instance variables set before #initialize" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject(configuration: "configuration", another_dep: "another_dep")
+    end
+  end
+
+  let(:framework_class) {
+    Class.new do
+      def self.new(configuration:, **args)
+        allocate.tap do |obj|
+          obj.instance_variable_set :@configuration, configuration
+          obj.send :initialize, **args
+        end
+      end
+    end
+  }
+
+  let(:parent_class) {
+    Class.new(framework_class) do
+      include Test::AutoInject.hash[:configuration]
+    end
+  }
+
+  let(:child_class) {
+    Class.new(parent_class) do
+      include Test::AutoInject.hash[:another_dep]
+    end
+
+  }
+
+  it "does not assign nil value from missing dependency arg to its instance variable if it is already defined" do
+    child = child_class.new
+    expect(child.configuration).to eq "configuration"
+    expect(child.another_dep).to eq "another_dep"
+  end
+
+  it "does assign an explicitly provided non-nil dependency to iits instance variable, even if it is already defined" do
+    child = child_class.new(configuration: "child configuration")
+    expect(child.configuration).to eq "child configuration"
+    expect(child.another_dep).to eq "another_dep"
+  end
+end

--- a/spec/integration/kwargs/inheritance/existing_ivars_before_initialize_spec.rb
+++ b/spec/integration/kwargs/inheritance/existing_ivars_before_initialize_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe "kwargs / inheritance / instance variables set before #initialize" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject(configuration: "configuration", another_dep: "another_dep")
+    end
+  end
+
+  let(:framework_class) {
+    Class.new do
+      def self.new(configuration:, **args)
+        allocate.tap do |obj|
+          obj.instance_variable_set :@configuration, configuration
+          obj.send :initialize, **args
+        end
+      end
+    end
+  }
+
+  let(:parent_class) {
+    Class.new(framework_class) do
+      include Test::AutoInject[:configuration]
+    end
+  }
+
+  let(:child_class) {
+    Class.new(parent_class) do
+      include Test::AutoInject[:another_dep]
+    end
+
+  }
+
+  it "does not assign nil value from missing dependency arg to its instance variable if it is already defined" do
+    child = child_class.new
+    expect(child.configuration).to eq "configuration"
+    expect(child.another_dep).to eq "another_dep"
+  end
+
+  it "does assign an explicitly provided non-nil dependency to iits instance variable, even if it is already defined" do
+    child = child_class.new(configuration: "child configuration")
+    expect(child.configuration).to eq "child configuration"
+    expect(child.another_dep).to eq "another_dep"
+  end
+end


### PR DESCRIPTION
This improves compatibility with objects initialized in unconventional ways.

In particular, it supports this case:

```ruby
module SomeFramework
  class Action
    def self.new(configuration:, **args)
      # Do some trickery to make it so `#initialize` on subclasses doesn't need
      # to sorry about accepting a configuration arg and passing it to super
      allocate.tap do |obj|
        obj.instance_variable_set :@configuration, configuration
        obj.send :initialize, **args
      end
    end
  end
end

module MyApp
  class BaseAction
    # Inject the configuration object, which is passed to
    # SomeFramework::Action.new but not all the way through to any subsequent
    # `#initialize` calls
    include Import[configuration: "web.action.configuration"]
  end

  class SomeAction < BaseAction 
    include Import["some_repo"]
  end
end

MyApp::SomeAction.new
# => #<MyApp::SomeAction:0x00007f9ad53e1530
#  @configuration=#<TheConfigurationObject>,
#  @some_repo=#<SomeRepo>>
```

This change does not break any existing behaviour, and improves compatibility with unconventional (but not illegitimate!) scenarios like this one.

@solnic @flash-gordon any objections to me adding this?