### PR TITLE
Pass keyword dependencies if super constructor accepts arguments with the splat operator

### DIFF
--- a/dry-auto_inject.gemspec
+++ b/dry-auto_inject.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path('../lib', __FILE__)

--- a/dry-auto_inject.gemspec
+++ b/dry-auto_inject.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_runtime_dependency 'dry-container', '>= 0.3.4'
 

--- a/dry-auto_inject.gemspec
+++ b/dry-auto_inject.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec', '~> 3.8'
 end

--- a/lib/dry/auto_inject.rb
+++ b/lib/dry/auto_inject.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'dry/auto_inject/builder'
-require 'dry/auto_inject/method_parameters'
 
 module Dry
   # Configure an auto-injection module
@@ -43,24 +42,5 @@ module Dry
   # @api public
   def self.AutoInject(container, options = {})
     AutoInject::Builder.new(container, options)
-  end
-
-  module AutoInject
-    # @api private
-    def self.super_parameters(klass, method_name)
-      Enumerator.new do |y|
-        loop do
-          method = klass.instance_method(method_name)
-
-          if method.nil? || method.owner.equal?(klass)
-            y << MethodParameters::EMPTY
-            break
-          else
-            y << MethodParameters.new(method.parameters)
-            klass = method.owner
-          end
-        end
-      end
-    end
   end
 end

--- a/lib/dry/auto_inject.rb
+++ b/lib/dry/auto_inject.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/auto_inject/builder'
+require 'dry/auto_inject/method_parameters'
 
 module Dry
   # Configure an auto-injection module
@@ -46,9 +47,20 @@ module Dry
 
   module AutoInject
     # @api private
-    def self.super_method(klass, method)
-      method = klass.instance_method(method)
-      method unless method.owner.equal?(klass)
+    def self.super_parameters(klass, method_name)
+      Enumerator.new do |y|
+        loop do
+          method = klass.instance_method(method_name)
+
+          if method.nil? || method.owner.equal?(klass)
+            y << MethodParameters::EMPTY
+            break
+          else
+            y << MethodParameters.new(method.parameters)
+            klass = method.owner
+          end
+        end
+      end
     end
   end
 end

--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -29,11 +29,11 @@ module Dry
       end
 
       def names
-        @map.keys
+        @name ||= @map.keys
       end
 
       def to_h
-        @map.dup.to_h
+        @map.dup
       end
       alias_method :to_hash, :to_h
 

--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -1,0 +1,52 @@
+require 'set'
+
+module Dry
+  module AutoInject
+    # @api private
+    class MethodParameters
+      PASS_THROUGH = [[:rest]]
+
+      attr_reader :parameters
+
+      def initialize(parameters)
+        @parameters = parameters
+      end
+
+      def splat?
+        return @splat if defined? @splat
+        @splat = parameters.any? { |type, _| type == :rest }
+      end
+
+      def sequential_arguments?
+        return @sequential_arguments if defined? @sequential_arguments
+        @sequential_arguments = parameters.any? { |type, _|
+          type == :req || type == :opt
+        }
+      end
+
+      def keyword_names
+        @keyword_names ||= parameters.each_with_object(Set.new) { |(type, name), names|
+          names << name if type == :key || type == :keyreq
+        }
+      end
+
+      def keyword?(name)
+        keyword_names.include?(name)
+      end
+
+      def empty?
+        parameters.empty?
+      end
+
+      def length
+        parameters.length
+      end
+
+      def pass_through?
+        parameters.eql?(PASS_THROUGH)
+      end
+
+      EMPTY = new([]).freeze
+    end
+  end
+end

--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -6,6 +6,22 @@ module Dry
     class MethodParameters
       PASS_THROUGH = [[:rest]]
 
+      def self.of(obj, name)
+        Enumerator.new do |y|
+          begin
+            method = obj.instance_method(name)
+          rescue NameError
+          end
+
+          loop do
+            break if method.nil?
+
+            y << MethodParameters.new(method.parameters)
+            method = method.super_method
+          end
+        end
+      end
+
       attr_reader :parameters
 
       def initialize(parameters)
@@ -46,7 +62,7 @@ module Dry
         parameters.eql?(PASS_THROUGH)
       end
 
-      EMPTY = new([]).freeze
+      EMPTY = new([])
     end
   end
 end

--- a/lib/dry/auto_inject/strategies/args.rb
+++ b/lib/dry/auto_inject/strategies/args.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/auto_inject/strategies/constructor'
+require 'dry/auto_inject/method_parameters'
 
 module Dry
   module AutoInject
@@ -22,7 +23,7 @@ module Dry
         end
 
         def define_initialize(klass)
-          super_parameters = Dry::AutoInject.super_parameters(klass, :initialize).each do |ps|
+          super_parameters = MethodParameters.of(klass, :initialize).each do |ps|
             # Look upwards past `def foo(*)` methods until we get an explicit list of parameters
             break ps unless ps.pass_through?
           end

--- a/lib/dry/auto_inject/strategies/args.rb
+++ b/lib/dry/auto_inject/strategies/args.rb
@@ -22,12 +22,15 @@ module Dry
         end
 
         def define_initialize(klass)
-          super_method = find_super(klass, :initialize)
+          super_parameters = Dry::AutoInject.super_parameters(klass, :initialize).each do |ps|
+            # Look upwards past `def foo(*)` methods until we get an explicit list of parameters
+            break ps unless ps.pass_through?
+          end
 
-          if super_method.nil? || super_method.parameters.empty?
+          if super_parameters.empty?
             define_initialize_with_params
           else
-            define_initialize_with_splat(super_method)
+            define_initialize_with_splat(super_parameters)
           end
         end
 
@@ -42,30 +45,19 @@ module Dry
           RUBY
         end
 
-        def define_initialize_with_splat(super_method)
-          super_params = if super_method.parameters.any? { |type, _| type == :rest }
+        def define_initialize_with_splat(super_parameters)
+          super_pass = if super_parameters.splat?
             '*args'
           else
-            "*args[0..#{super_method.parameters.length - 1}]"
+            "*args.take(#{super_parameters.length})"
           end
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(*args)
               #{dependency_map.names.map.with_index { |name, i| "@#{name} = args[#{i}]" }.join("\n")}
-              super(#{super_params})
+              super(#{super_pass})
             end
           RUBY
-        end
-
-        def find_super(klass, method_name)
-          super_method = Dry::AutoInject.super_method(klass, method_name)
-
-          # Look upwards past `def foo(*)` methods until we get an explicit list of parameters
-          while super_method && super_method.parameters == [[:rest]]
-            super_method = Dry::AutoInject.super_method(super_method.owner, :initialize)
-          end
-
-          super_method
         end
       end
 

--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dry/auto_inject/strategies/constructor'
+require 'dry/auto_inject/method_parameters'
 
 module Dry
   module AutoInject
@@ -22,7 +23,7 @@ module Dry
         end
 
         def define_initialize(klass)
-          super_params = Dry::AutoInject.super_parameters(klass, :initialize).first
+          super_params = MethodParameters.of(klass, :initialize).first
           super_pass = super_params.empty? ? '' : 'options'
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1

--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -23,12 +23,12 @@ module Dry
 
         def define_initialize(klass)
           super_params = Dry::AutoInject.super_parameters(klass, :initialize).first
-          super_call = super_params.empty? ? '' : 'options'
+          super_pass = super_params.empty? ? '' : 'options'
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(options)
               #{dependency_map.names.map { |name| "@#{name} = options[:#{name}] unless !options.key?(#{name}) && instance_variable_defined?(:'@#{name}')" }.join("\n")}
-              super(#{super_call})
+              super(#{super_pass})
             end
           RUBY
         end

--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -22,13 +22,13 @@ module Dry
         end
 
         def define_initialize(klass)
-          super_method = Dry::AutoInject.super_method(klass, :initialize)
-          super_params = super_method.nil? || super_method.parameters.empty? ? '' : 'options'
+          super_params = Dry::AutoInject.super_parameters(klass, :initialize).first
+          super_call = super_params.empty? ? '' : 'options'
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(options)
               #{dependency_map.names.map { |name| "@#{name} = options[:#{name}] unless !options.key?(#{name}) && instance_variable_defined?(:'@#{name}')" }.join("\n")}
-              super(#{super_params})
+              super(#{super_call})
             end
           RUBY
         end

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -86,7 +86,7 @@ module Dry
             # Assign instance variables, but only if the ivar is not
             # previously defined (this improves compatibility with objects
             # initialized in unconventional ways)
-            unless !kwargs.key?(name) && destination.instance_variable_defined?(:"@#{name}")
+            if kwargs.key?(name) || !destination.instance_variable_defined?(:"@#{name}")
               destination.instance_variable_set :"@#{name}", kwargs[name]
             end
           end

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -86,7 +86,7 @@ module Dry
             # Assign instance variables, but only if the ivar is not
             # previously defined (this improves compatibility with objects
             # initialized in unconventional ways)
-            unless kwargs[name].nil? && destination.instance_variable_defined?(:"@#{name}")
+            unless !kwargs.key?(name) && destination.instance_variable_defined?(:"@#{name}")
               destination.instance_variable_set :"@#{name}", kwargs[name]
             end
           end

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -40,7 +40,7 @@ module Dry
           assign_dependencies = method(:assign_dependencies)
           slice_kwargs = method(:slice_kwargs)
 
-          instance_mod.class_exec(dependency_map) do |dependency_map|
+          instance_mod.class_exec do
             define_method :initialize do |**kwargs|
               assign_dependencies.(kwargs, self)
 
@@ -59,7 +59,7 @@ module Dry
           assign_dependencies = method(:assign_dependencies)
           slice_kwargs = method(:slice_kwargs)
 
-          instance_mod.class_exec(dependency_map) do |dependency_map|
+          instance_mod.class_exec do
             define_method :initialize do |*args, **kwargs|
               assign_dependencies.(kwargs, self)
 

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -25,7 +25,10 @@ module Dry
         end
 
         def define_initialize(klass)
-          super_parameters = Dry::AutoInject.super_parameters(klass, :initialize).first
+          super_parameters = MethodParameters.of(klass, :initialize).each do |ps|
+            # Look upwards past `def foo(*)` methods until we get an explicit list of parameters
+            break ps unless ps.pass_through?
+          end
 
           if super_parameters.splat? || super_parameters.sequential_arguments?
             define_initialize_with_splat(super_parameters)

--- a/spec/dry/auto_inject_spec.rb
+++ b/spec/dry/auto_inject_spec.rb
@@ -321,8 +321,8 @@ RSpec.describe Dry::AutoInject do
 
         attr_reader :other
 
-        def initialize(other: nil, **args)
-          super(**args)
+        def initialize(other: nil, **kwargs)
+          super(**kwargs)
           @other = other
         end
       end
@@ -332,7 +332,7 @@ RSpec.describe Dry::AutoInject do
       Class.new(parent_class) do
         attr_reader :foo
 
-        def initialize(**args)
+        def initialize(**kwargs)
           super
           @foo = 'bar'
         end

--- a/spec/integration/hash/inheritance/parent_class_injections_spec.rb
+++ b/spec/integration/hash/inheritance/parent_class_injections_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe "hash / inheritance / parent class also auto-injecting" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject(one: "dep 1", two: "dep 2").hash
+    end
+  end
+
+  describe "differing injections" do
+    let(:parent_class) {
+      Class.new do
+        include Test::AutoInject[:one]
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[:two]
+      end
+    }
+
+    specify "auto-injections from parent class are available in child class" do
+      child = child_class.new
+      expect(child.one).to eq "dep 1"
+      expect(child.two).to eq "dep 2"
+    end
+  end
+
+  describe "matching overlapping injections" do
+    let(:parent_class) {
+      Class.new do
+        include Test::AutoInject[:one, :two]
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[:two]
+      end
+    }
+
+    specify "the child class' injection is kept" do
+      child = child_class.new
+      expect(child.one).to eq "dep 1"
+      expect(child.two).to eq "dep 2"
+    end
+  end
+
+  describe "differing overlapping injections" do
+    let(:parent_class) {
+      Class.new do
+        include Test::AutoInject[:one, :two]
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[one: :two]
+      end
+    }
+
+    specify "the child class' injection is kept" do
+      child = child_class.new
+      expect(child.one).to eq "dep 2"
+      expect(child.two).to eq "dep 2"
+    end
+  end
+end

--- a/spec/integration/kwargs/inheritance/parent_class_injections_spec.rb
+++ b/spec/integration/kwargs/inheritance/parent_class_injections_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe "kwargs / inheritance / parent class also auto-injecting" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject(one: "dep 1", two: "dep 2")
+    end
+  end
+
+  describe "differing injections" do
+    let(:parent_class) {
+      Class.new do
+        include Test::AutoInject[:one]
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[:two]
+      end
+    }
+
+    specify "auto-injections from parent class are available in child class" do
+      child = child_class.new
+      expect(child.one).to eq "dep 1"
+      expect(child.two).to eq "dep 2"
+    end
+  end
+
+  describe "matching overlapping injections" do
+    let(:parent_class) {
+      Class.new do
+        include Test::AutoInject[:one, :two]
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[:two]
+      end
+    }
+
+    specify "the child class' injection is kept" do
+      child = child_class.new
+      expect(child.one).to eq "dep 1"
+      expect(child.two).to eq "dep 2"
+    end
+  end
+
+  describe "differing overlapping injections" do
+    let(:parent_class) {
+      Class.new do
+        include Test::AutoInject[:one, :two]
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[one: :two]
+      end
+    }
+
+    specify "the child class' injection is kept" do
+      child = child_class.new
+      expect(child.one).to eq "dep 2"
+      expect(child.two).to eq "dep 2"
+    end
+  end
+end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -106,4 +106,31 @@ RSpec.describe "kwargs / super #initialize method" do
       expect(instance.args).to eq [one: "dep 1"]
     end
   end
+
+  describe "ignoring pass-through constructors" do
+    let(:parent_class) {
+      Class.new do
+        def initialize
+        end
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Module.new {
+          def initialize(*)
+            super
+          end
+        }
+
+        include Test::AutoInject[:one]
+      end
+    }
+
+    it "don't pass deps if the final constructor will choke on them" do
+      instance = child_class.new
+
+      expect(instance.one).to eq "dep 1"
+    end
+  end
 end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -79,4 +79,30 @@ RSpec.describe "kwargs / super #initialize method" do
       expect(instance.one).to eq "dep 1"
     end
   end
+
+  describe "passing dependencies where superclass has a splat in arguments" do
+    let(:parent_class) {
+      Class.new do
+        attr_reader :dep, :args
+
+        def initialize(*args)
+          @dep = args[0].fetch(:one)
+          @args = args
+        end
+      end
+    }
+
+    let(:child_class) {
+      Class.new(parent_class) do
+        include Test::AutoInject[:one]
+      end
+    }
+
+    it "passes dependencies assuming the parent class can take them" do
+      instance = child_class.new
+
+      expect(instance.dep).to eq "dep 1"
+      expect(instance.args).to eq [one: "dep 1"]
+    end
+  end
 end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe "kwargs / super #initialize method" do
     it "passes dependencies assuming the parent class can take them" do
       instance = child_class.new
 
+      expect(instance.one).to eq "dep 1"
       expect(instance.dep).to eq "dep 1"
       expect(instance.args).to eq [one: "dep 1"]
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,9 @@ module Test
 end
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.filter_run_when_matching :focus
+
   config.after do
     Test.remove_constants
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,4 +32,8 @@ RSpec.configure do |config|
   config.after do
     Test.remove_constants
   end
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
 end

--- a/spec/unit/method_parameters_spec.rb
+++ b/spec/unit/method_parameters_spec.rb
@@ -1,0 +1,51 @@
+require 'dry/auto_inject/method_parameters'
+
+RSpec.describe Dry::AutoInject::MethodParameters do
+  let(:parameters) { described_class }
+
+  describe '.of' do
+    it 'returns method parameters' do
+      klass = Class.new {
+        def foo(a, b = nil, *c, d:, e: nil, **f, &g)
+        end
+      }
+
+      all_parameters = parameters.of(klass, :foo).to_a
+
+      expect(all_parameters.size).to eq 1
+      expect(all_parameters[0].parameters).
+        to eq([
+                [:req, :a], [:opt, :b], [:rest, :c],
+                [:keyreq, :d], [:key, :e], [:keyrest, :f],
+                [:block, :g]
+              ])
+    end
+
+    it 'returns empty array when no method defined' do
+      expect(parameters.of(Object, :non_existing).to_a).to be_empty
+    end
+
+    it 'returns parameters for build-in methods' do
+      all_parameters = parameters.of(BasicObject, :initialize).to_a
+
+      expect(all_parameters.size).to eq 1
+      expect(all_parameters[0]).to be_empty
+    end
+
+    it 'lists methods defined in mixins' do
+      klass = Class.new {
+        include Module.new {
+          def initialize(*)
+            super
+          end
+        }
+      }
+
+      all_parameters = parameters.of(klass, :initialize).to_a
+
+      expect(all_parameters.size).to eq 2
+      expect(all_parameters[0].parameters).to eql([[:rest]])
+      expect(all_parameters[1]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Now the keyword strategy will pass dependencies to an existing `initialize` method if it accepts an arbitrary number of arguments. This enables seamless integration with ROM's repositories. The required changes in ROM have been applied already so we're going to have it in ROM 5.

Resolves #46, Resolves #49