### PR TITLE
Travis: Update CI matrix, include 2.6.1, use JRuby 9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: ruby
 cache: bundler
 bundler_args: --without tools
-script:
-  - bundle exec rake
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
+  - 2.6.1
   - 2.5.3
   - 2.4.5
   - 2.3.8
-  - jruby-9.2.4.1
+  - jruby-9.2.5.0
 env:
   global:
     - COVERAGE=true


### PR DESCRIPTION
This PR updates the Travis configuration:

  - drop default `script` directive
  - Matrix: use latest JRuby release
  - Matrix: add Ruby 2.6.1