### PR TITLE
Rename instance method name

### DIFF
--- a/lib/dry/auto_inject/dependency_map.rb
+++ b/lib/dry/auto_inject/dependency_map.rb
@@ -29,7 +29,7 @@ module Dry
       end
 
       def names
-        @name ||= @map.keys
+        @names ||= @map.keys
       end
 
       def to_h


### PR DESCRIPTION
Rename of the instance method name to keep it consistent with the convention.