### PR TITLE
CI: use 2.4.6, 2.6.3, jruby-9.2.7.0, drop 2.3.8 (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.6.2
   - 2.5.5
   - 2.4.6
-  - 2.3.8
   - jruby-9.2.6.0
   - truffleruby
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.6.2
   - 2.5.5
   - 2.4.6
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
   - truffleruby
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ bundler_args: --without tools
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.6.2
+  - 2.6.3
   - 2.5.5
   - 2.4.6
   - jruby-9.2.7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ after_success:
 rvm:
   - 2.6.2
   - 2.5.5
-  - 2.4.5
+  - 2.4.6
   - 2.3.8
   - jruby-9.2.6.0
   - truffleruby


### PR DESCRIPTION
This PR updates the CI matrix to use 2.4.6.