### PR TITLE
Proof of concept idea injection dependencies by specific pattern

### DIFF
--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -15,10 +15,17 @@ module Dry
       def initialize(container, options = {})
         @container = container
         @strategies = options.fetch(:strategies) { Strategies }
+        @pattern = options.fetch(:pattern) { nil }
+      end
+
+      def allow(pattern)
+        AutoInject::Builder.new(@container, pattern: pattern, strategies: @strategies)
       end
 
       # @api public
       def [](*dependency_names)
+        raise unless match_by_pattern?(dependency_names)
+
         default[*dependency_names]
       end
 
@@ -27,6 +34,10 @@ module Dry
       end
 
       private
+
+      def match_by_pattern?(dependency_names)
+        @pattern.nil? || dependency_names.all? { |dependency| dependency.match(@pattern) }
+      end
 
       def method_missing(name, *args, &block)
         if strategies.key?(name)

--- a/spec/integration/allow_inject_spec.rb
+++ b/spec/integration/allow_inject_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe "allow condition" do
+  describe "allow" do
+    before do
+      module Test
+        AutoInject = Dry::AutoInject({one: 1, two: 2})
+        OnlyOneInject = AutoInject.allow(/one/)
+      end
+    end
+
+    subject(:instance) { including_class.new }
+
+    context 'when user injects allowed keys' do
+      let(:including_class) do
+        Class.new do
+          include Test::OnlyOneInject[:one]
+        end
+      end
+
+      it { expect(instance.one).to eq 1 }
+    end
+
+    context 'when user injects all keys' do
+      let(:including_class) do
+        Class.new do
+          include Test::OnlyOneInject[:one, :two]
+        end
+      end
+
+      it { expect { instance }.to raise_error }
+    end
+  end
+end


### PR DESCRIPTION
Hey, I have a idea how to improve injector for scopes in business logic.

_I create simple PR for discussing and share this idea_

## Idea
Imagine a situation when you have an application with 2 different scopes: `Accounts` and `Orders`. And in each scope (or domain) you have specific operations and repositories. And in account repo we have a similar method name `find`:

```ruby
module Accounts
  # Operations for accounts
  module Operations
    class List
      # ...
    end

    class Show
      # ...
    end
  end

  # Repos for accounts
  module Repositories
    class Accounts
      def find(id)
        # ...
      end
    end
  end
end

module Orders
  # Operation for orders
  module Operations
    class Create
      # ...
    end

    class Checkout
      # ...
    end
  end

  # Repos for orders
  module Repositories
    class Orders
      # ...
    end

    class Accounts
      def find(order_id)
        # ...
      end
    end
  end
end
```

We put all these classes into a container and now we can fail if someone injects account repo from `Accounts` to `Orders` scope:

```ruby
module Orders
  # Operation for orders
  module Operations
    class Create
      include Inject['orders.repositories.accounts'] # OK for us
      include Inject['accounts.repositories.accounts'] # BAD but we get a exeption ONLY after first call

      # ...
    end
  end
end
```

Important thing: this code (with injection `'accounts.repositories.accounts'`) raise error only after booting and first real call.

For detecting these situations I introduce `allow` method with simple regexp pattern:

```ruby
module Accounts
  Inject = Inject.allow(/\Aaccounts.+/) # allow to inject only "accounts.*" keys

  # ...
end

module Orders
  Inject = Inject.allow(/\Aorders.+/) # allow to inject only "orders.*" keys

  # ...
end
```

And now, if we will try to inject `'accounts.repositories.accounts'` to `Orders::Operations::Create` we fail on creating an instance of operation.

## Implementation

It's just a proposal of my vision. I'm not sure that `allow` better name for this. But I'll be happy to discuss it with everyone ❤️ 