### PR TITLE
Fix keyword warnings

### DIFF
--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -50,7 +50,7 @@ module Dry
               super_kwargs = slice_kwargs.(kwargs, super_parameters)
 
               if super_kwargs.any?
-                super(super_kwargs)
+                super(**super_kwargs)
               else
                 super()
               end

--- a/spec/integration/hash/inheritance/existing_ivars_before_initialize_spec.rb
+++ b/spec/integration/hash/inheritance/existing_ivars_before_initialize_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe "kwargs / inheritance / instance variables set before #initialize
 
   let(:framework_class) {
     Class.new do
-      def self.new(configuration:, **args)
+      def self.new(options)
         allocate.tap do |obj|
-          obj.instance_variable_set :@configuration, configuration
-          obj.send :initialize, **args
+          obj.instance_variable_set :@configuration, options.fetch(:configuration)
+          opts = options.dup
+          opts.delete(:configuration)
+          obj.send :initialize, opts
         end
       end
     end


### PR DESCRIPTION
Specs shouldn't have used keywords, it's leftovers from copy/paste.