### PR TITLE
Forward Blocks Passed to Constructor when using Kwargs Injection Strategy.

### DIFF
--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -14,12 +14,12 @@ module Dry
           class_mod.class_exec(container, dependency_map) do |container, dependency_map|
             map = dependency_map.to_h
 
-            define_method :new do |*args, **kwargs|
+            define_method :new do |*args, **kwargs, &block|
               map.each do |name, identifier|
                 kwargs[name] = container[identifier] unless kwargs.key?(name)
               end
 
-              super(*args, **kwargs)
+              super(*args, **kwargs, &block)
             end
           end
         end
@@ -44,15 +44,15 @@ module Dry
           slice_kwargs = method(:slice_kwargs)
 
           instance_mod.class_exec do
-            define_method :initialize do |**kwargs|
+            define_method :initialize do |**kwargs, &block|
               assign_dependencies.(kwargs, self)
 
               super_kwargs = slice_kwargs.(kwargs, super_parameters)
 
               if super_kwargs.any?
-                super(**super_kwargs)
+                super(**super_kwargs, &block)
               else
-                super()
+                super(&block)
               end
             end
           end
@@ -63,18 +63,18 @@ module Dry
           slice_kwargs = method(:slice_kwargs)
 
           instance_mod.class_exec do
-            define_method :initialize do |*args, **kwargs|
+            define_method :initialize do |*args, **kwargs, &block|
               assign_dependencies.(kwargs, self)
 
               if super_parameters.splat?
-                super(*args, **kwargs)
+                super(*args, **kwargs, &block)
               else
                 super_kwargs = slice_kwargs.(kwargs, super_parameters)
 
                 if super_kwargs.any?
-                  super(*args, **super_kwargs)
+                  super(*args, **super_kwargs, &block)
                 else
-                  super(*args)
+                  super(*args, &block)
                 end
               end
             end

--- a/spec/integration/kwargs_spec.rb
+++ b/spec/integration/kwargs_spec.rb
@@ -1,17 +1,38 @@
 # frozen_string_literal: true
 
-RSpec.describe 'kwargs' do
-  it 'supports explicit injection of falsey values' do
+RSpec.describe "kwargs" do
+  before do
     module Test
-      AutoInject = Dry::AutoInject(one: 'dep 1')
+      AutoInject = Dry::AutoInject(one: "dep 1")
     end
+  end
 
+  it "supports explicit injection of falsey values" do
     obj = Class.new do
       include Test::AutoInject[:one]
     end
 
-    expect(obj.new.one).to eq 'dep 1'
+    expect(obj.new.one).to eq "dep 1"
     expect(obj.new(one: false).one).to be false
     expect(obj.new(one: nil).one).to be nil
+  end
+
+  it "forwards the block to the constructor" do
+    klass = Class.new do
+      include Test::AutoInject[:one]
+
+      attr_reader :block
+
+      def initialize(*args, &block)
+        super(*args)
+        @block = block
+      end
+    end
+
+    block = -> {}
+
+    expect(klass.new).to have_attributes(one: "dep 1", block: nil)
+    expect(klass.new(&block)).to have_attributes(one: "dep 1", block: block)
+    expect(klass.new(one: nil, &block)).to have_attributes(one: nil, block: block)
   end
 end


### PR DESCRIPTION
Forwards blocks given to new/initialize to super method when using Kwargs injection strategy.

Presently, the `new` method defined by the strategy would swallow and discard any block given, thus not allowing for an initializer to accept a block.
