### PR TITLE
Fix Ruby 2.7.1 kwargs incompatibility

### DIFF
--- a/lib/dry/auto_inject/strategies/hash.rb
+++ b/lib/dry/auto_inject/strategies/hash.rb
@@ -17,14 +17,14 @@ module Dry
                 obj[name] = options[name] || container[identifier]
               }.merge(options)
 
-              super(deps)
+              super(**deps)
             end
           end
         end
 
         def define_initialize(klass)
           super_params = MethodParameters.of(klass, :initialize).first
-          super_pass = super_params.empty? ? '' : 'options'
+          super_pass = super_params.empty? ? '' : '**options'
 
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(options)


### PR DESCRIPTION
Hi,
I was receiving following warnings on Ruby 2.7.1:

```
../gems/dry-auto_inject-0.7.0/lib/dry/auto_inject/strategies/hash.rb:20: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
../gems/dry-auto_inject-0.7.0/lib/dry/auto_inject/strategies/hash.rb:32: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

Below changes seems to fix the problem.