### PR TITLE
Add Support For `...` Passthrgouh

### DIFF
--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -87,7 +87,7 @@ module Dry
       end
 
       def pass_through?
-        PASS_THROUGH.any? { |pass_through_params| parameters.eql?(pass_through_params) }
+        PASS_THROUGH.include?(parameters)
       end
 
       EMPTY = new([])

--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -6,7 +6,7 @@ module Dry
   module AutoInject
     # @api private
     class MethodParameters
-      PASS_THROUGH = [[[:rest]], [[:rest, :*], [:block, :&]]]
+      PASS_THROUGH = [[%i[rest]], [%i[rest *], %i[block &]]]
 
       if RUBY_VERSION >= '2.4.4.' && !defined? JRUBY_VERSION
         def self.of(obj, name)

--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -6,7 +6,7 @@ module Dry
   module AutoInject
     # @api private
     class MethodParameters
-      PASS_THROUGH = [[:rest]]
+      PASS_THROUGH = [[[:rest]], [[:rest, :*], [:block, :&]]]
 
       if RUBY_VERSION >= '2.4.4.' && !defined? JRUBY_VERSION
         def self.of(obj, name)
@@ -87,7 +87,7 @@ module Dry
       end
 
       def pass_through?
-        parameters.eql?(PASS_THROUGH)
+        PASS_THROUGH.any? { |pass_through_params| parameters.eql?(pass_through_params) }
       end
 
       EMPTY = new([])

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -26,7 +26,7 @@ module Dry
 
         def define_initialize(klass)
           super_parameters = MethodParameters.of(klass, :initialize).each do |ps|
-            # Look upwards past `def foo(*)` and `def foo(...)` methods 
+            # Look upwards past `def foo(*)` and `def foo(...)` methods
             # until we get an explicit list of parameters
             break ps unless ps.pass_through?
           end

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -26,7 +26,8 @@ module Dry
 
         def define_initialize(klass)
           super_parameters = MethodParameters.of(klass, :initialize).each do |ps|
-            # Look upwards past `def foo(*)` and `def foo(...)` methods until we get an explicit list of parameters
+            # Look upwards past `def foo(*)` and `def foo(...)` methods 
+            # until we get an explicit list of parameters
             break ps unless ps.pass_through?
           end
 

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -26,7 +26,7 @@ module Dry
 
         def define_initialize(klass)
           super_parameters = MethodParameters.of(klass, :initialize).each do |ps|
-            # Look upwards past `def foo(*)` methods until we get an explicit list of parameters
+            # Look upwards past `def foo(*)` and `def foo(...)` methods until we get an explicit list of parameters
             break ps unless ps.pass_through?
           end
 

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -132,5 +132,25 @@ RSpec.describe 'kwargs / super #initialize method' do
 
       expect(instance.one).to eq 'dep 1'
     end
+
+    context 'when pass-through is performed via ...' do
+      let(:child_class) {
+        Class.new(parent_class) do
+          include Module.new {
+            def initialize(...)
+              super(...)
+            end
+          }
+
+          include Test::AutoInject[:one]
+        end
+      }
+
+      it "don't pass deps if the final constructor will choke on them" do
+        instance = child_class.new
+
+        expect(instance.one).to eq 'dep 1'
+      end
+    end
   end
 end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -133,23 +133,26 @@ RSpec.describe 'kwargs / super #initialize method' do
       expect(instance.one).to eq 'dep 1'
     end
 
-    context 'when pass-through is performed via ...' do
-      let(:child_class) {
-        Class.new(parent_class) do
-          include Module.new {
+    if RUBY_VERSION >= '2.7' && !defined? JRUBY_VERSION
+      context 'when pass-through is performed via ...' do
+        let(:child_class) {
+          klass = Class.new(parent_class) do
+            include Test::AutoInject[:one]
+          end
+          klass.class_eval <<-RUBY
             def initialize(...)
               super(...)
             end
-          }
+          RUBY
+          
+          klass
+        }
 
-          include Test::AutoInject[:one]
+        it "don't pass deps if the final constructor will choke on them" do
+          instance = child_class.new
+
+          expect(instance.one).to eq 'dep 1'
         end
-      }
-
-      it "don't pass deps if the final constructor will choke on them" do
-        instance = child_class.new
-
-        expect(instance.one).to eq 'dep 1'
       end
     end
   end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -133,18 +133,18 @@ RSpec.describe 'kwargs / super #initialize method' do
       expect(instance.one).to eq 'dep 1'
     end
 
-    if RUBY_VERSION >= '2.7' && !defined? JRUBY_VERSION
-      context 'when pass-through is performed via ...' do
+    if RUBY_VERSION >= "2.7" && !defined? JRUBY_VERSION
+      context "when pass-through is performed via ..." do
         let(:child_class) {
           klass = Class.new(parent_class) do
             include Test::AutoInject[:one]
           end
-          klass.class_eval <<-RUBY
+          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def initialize(...)
               super(...)
             end
           RUBY
-          
+
           klass
         }
 

--- a/spec/integration/kwargs_spec.rb
+++ b/spec/integration/kwargs_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "kwargs" do
 
       attr_reader :block
 
-      def initialize(*args, &block)
-        super(*args)
+      def initialize(*args, **kwargs, &block)
+        super(*args, **kwargs)
         @block = block
       end
     end


### PR DESCRIPTION
Currently, MethodParameters has a `pass_through?` method which supports `def foo(*)` cases.

Ruby 2.7, however, adds a new method of passthrough, namely `def foo(...)`.

MethodParameters is not aware of that which results in kwargs auto inject mistakenly believing that the parent class supports `splat` arguments.

I didn't report this as an issue since I already had a fix but let me know if you need me to do so or if tests are required in more places.

Edit: Looks like this fix _only_ works on 2.7. I'll look into other ruby versions.