### PR TITLE
Turn builder into an Object descendant

### DIFF
--- a/lib/dry/auto_inject/builder.rb
+++ b/lib/dry/auto_inject/builder.rb
@@ -5,7 +5,7 @@ require 'dry/auto_inject/injector'
 
 module Dry
   module AutoInject
-    class Builder < BasicObject
+    class Builder
       # @api private
       attr_reader :container
 


### PR DESCRIPTION
Since the builder is an object that the user has access to, it can
lead to all sorts of confusing situations when it's misused and it's
not responding to standard Object methods. There's no good reason why
it should be a BasicObject, since it's not exposing any complex DSL.

Issues: https://github.com/dry-rb/dry-auto_inject/issues/75

Same MR like https://github.com/dry-rb/dry-matcher/pull/32