### PR TITLE
Change what constructors are considered pass-through

### DIFF
--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -6,7 +6,7 @@ module Dry
   module AutoInject
     # @api private
     class MethodParameters
-      PASS_THROUGH = [[%i[rest]], [%i[rest *], %i[block &]]]
+      PASS_THROUGH = [[%i[rest]], [%i[rest], %i[keyrest]]]
 
       def self.of(obj, name)
         Enumerator.new do |y|

--- a/spec/integration/kwargs/inheritance/parent_class_injections_spec.rb
+++ b/spec/integration/kwargs/inheritance/parent_class_injections_spec.rb
@@ -66,4 +66,34 @@ RSpec.describe 'kwargs / inheritance / parent class also auto-injecting' do
       expect(child.two).to eq 'dep 2'
     end
   end
+
+  describe "support for argument delegation with new syntax" do
+    let(:parent_class) do
+      Class.new do
+        def initialize(...)
+          delegated(...)
+        end
+
+        def delegated(one:)
+          @one = one
+        end
+      end
+    end
+
+    let(:child_class) do
+      Class.new(parent_class) do
+        include Test::AutoInject[:one]
+
+        def initialize(*)
+          super
+        end
+        ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
+      end
+    end
+
+    it "passes deps to the base constructor" do
+      child = child_class.new
+      expect(child).to have_attributes(one: "dep 1")
+    end
+  end
 end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -127,32 +127,49 @@ RSpec.describe 'kwargs / super #initialize method' do
       end
     }
 
-    it "don't pass deps if the final constructor will choke on them" do
+    it "doesn't pass deps if the final constructor will choke on them" do
       instance = child_class.new
 
       expect(instance.one).to eq 'dep 1'
     end
 
-    if RUBY_VERSION >= "2.7" && !defined? JRUBY_VERSION
-      context "when pass-through is performed via ..." do
-        let(:child_class) {
-          klass = Class.new(parent_class) do
-            include Test::AutoInject[:one]
-          end
-          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def initialize(...)
-              super(...)
+    context "with keywords" do
+      let(:child_class) do
+        Class.new(parent_class) do
+          include Module.new {
+            def initialize(*, **)
+              super
             end
-          RUBY
+          }
 
-          klass
-        }
-
-        it "don't pass deps if the final constructor will choke on them" do
-          instance = child_class.new
-
-          expect(instance.one).to eq 'dep 1'
+          include Test::AutoInject[:one]
         end
+      end
+
+      it "doesn't pass deps if the final constructor will choke on them" do
+        instance = child_class.new
+
+        expect(instance.one).to eq 'dep 1'
+      end
+    end
+
+    context "only keywords" do
+      let(:child_class) do
+        Class.new(parent_class) do
+          include Module.new {
+            def initialize(**)
+              super
+            end
+          }
+
+          include Test::AutoInject[:one]
+        end
+      end
+
+      it "doesn't pass deps if the final constructor will choke on them" do
+        instance = child_class.new
+
+        expect(instance.one).to eq 'dep 1'
       end
     end
   end


### PR DESCRIPTION
This PR addresses #77. Using `...` for calling super methods is not the only way this syntax works, it also works for delegation. From dry-auto_inject's POV there's no way to figure out what's going to happen after delegation, it may work, it may not.

I removed the old spec (it didn't work btw: it didn't start falling after the change) and changed what can be considered as a pass-through constructor.

@parndt please please confirm this works for you