### PR TITLE
Generate private dependency reader methods

### DIFF
--- a/lib/dry/auto_inject/strategies/constructor.rb
+++ b/lib/dry/auto_inject/strategies/constructor.rb
@@ -40,6 +40,7 @@ module Dry
         def define_readers
           readers = dependency_map.names.map { ":#{_1}" }
           instance_mod.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+            private
             attr_reader #{readers.join(", ")} # attr_reader :dep1, :dep2
           RUBY
           self

--- a/spec/dry/auto_inject_spec.rb
+++ b/spec/dry/auto_inject_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe Dry::AutoInject do
   def assert_valid_object(object)
-    expect(object.one).to eq 1
-    expect(object.two).to eq 2
-    expect(object.three).to eq 3
+    expect(object.send(:one)).to eq 1
+    expect(object.send(:two)).to eq 2
+    expect(object.send(:three)).to eq 3
   end
 
   before do
@@ -58,9 +58,9 @@ RSpec.describe Dry::AutoInject do
 
     context "aliased dependencies" do
       def assert_valid_object(object)
-        expect(object.one).to eq 1
-        expect(object.two).to eq 2
-        expect(object.last).to eq 3
+        expect(object.send(:one)).to eq 1
+        expect(object.send(:two)).to eq 2
+        expect(object.send(:last)).to eq 3
       end
 
       let(:parent_class) do
@@ -101,7 +101,7 @@ RSpec.describe Dry::AutoInject do
             child_instance = child_class.new(*args)
 
             assert_valid_object(child_instance)
-            expect(child_instance.first).to eq 1
+            expect(child_instance.send(:first)).to eq 1
           end
         end
       end
@@ -122,7 +122,7 @@ RSpec.describe Dry::AutoInject do
             child_instance = child_class.new(*args)
 
             assert_valid_object(child_instance)
-            expect(child_instance.args).to eq [1, 2, 3]
+            expect(child_instance.send(:args)).to eq [1, 2, 3]
           end
         end
       end
@@ -147,9 +147,9 @@ RSpec.describe Dry::AutoInject do
             child_instance = child_class.new(*args)
 
             assert_valid_object(child_instance)
-            expect(child_instance.first).to eq 1
-            expect(child_instance.middle).to eq [2]
-            expect(child_instance.last).to eq 3
+            expect(child_instance.send(:first)).to eq 1
+            expect(child_instance.send(:middle)).to eq [2]
+            expect(child_instance.send(:last)).to eq 3
           end
         end
       end
@@ -204,9 +204,9 @@ RSpec.describe Dry::AutoInject do
 
     context "aliased dependencies" do
       def assert_valid_object(object)
-        expect(object.one).to eq 1
-        expect(object.two).to eq 2
-        expect(object.last).to eq 3
+        expect(object.send(:one)).to eq 1
+        expect(object.send(:two)).to eq 2
+        expect(object.send(:last)).to eq 3
       end
 
       let(:parent_class) do
@@ -247,7 +247,7 @@ RSpec.describe Dry::AutoInject do
             child_instance = child_class.new(args)
 
             assert_valid_object(child_instance)
-            expect(child_instance.first).to eq 1
+            expect(child_instance.send(:first)).to eq 1
           end
         end
       end
@@ -277,8 +277,8 @@ RSpec.describe Dry::AutoInject do
       it "works" do
         instance = klass.new
 
-        expect(instance.one).to eq 1
-        expect(instance.two).to eq 2
+        expect(instance.send(:one)).to eq 1
+        expect(instance.send(:two)).to eq 2
       end
     end
 
@@ -307,8 +307,8 @@ RSpec.describe Dry::AutoInject do
         klasses.each do |klass|
           instance = klass.new
 
-          expect(instance.one).to eq 1
-          expect(instance.two).to eq 2
+          expect(instance.send(:one)).to eq 1
+          expect(instance.send(:two)).to eq 2
         end
       end
     end
@@ -376,9 +376,9 @@ RSpec.describe Dry::AutoInject do
       end
 
       def assert_valid_object(object)
-        expect(object.one).to eq 1
-        expect(object.two).to eq 2
-        expect(object.last).to eq 3
+        expect(object.send(:one)).to eq 1
+        expect(object.send(:two)).to eq 2
+        expect(object.send(:last)).to eq 3
       end
 
       let(:parent_class) do
@@ -419,7 +419,7 @@ RSpec.describe Dry::AutoInject do
             child_instance = child_class.new(**args)
 
             assert_valid_object(child_instance)
-            expect(child_instance.first).to eq 1
+            expect(child_instance.send(:first)).to eq 1
           end
         end
       end
@@ -440,7 +440,7 @@ RSpec.describe Dry::AutoInject do
             child_instance = child_class.new(other: "other", **args)
 
             assert_valid_object(child_instance)
-            expect(child_instance.other).to eq "other"
+            expect(child_instance.send(:other)).to eq "other"
           end
         end
       end
@@ -500,8 +500,8 @@ RSpec.describe Dry::AutoInject do
         klasses.each do |klass|
           instance = klass.new
 
-          expect(instance.one).to eq 1
-          expect(instance.two).to eq 2
+          expect(instance.send(:one)).to eq 1
+          expect(instance.send(:two)).to eq 2
         end
       end
     end
@@ -524,10 +524,10 @@ RSpec.describe Dry::AutoInject do
         it "works" do
           instance = klass.new(:other)
 
-          expect(instance.other).to eq :other
-          expect(instance.one).to eq 1
-          expect(instance.two).to eq 2
-          expect(instance.three).to eq 3
+          expect(instance.send(:other)).to eq :other
+          expect(instance.send(:one)).to eq 1
+          expect(instance.send(:two)).to eq 2
+          expect(instance.send(:three)).to eq 3
         end
       end
 
@@ -551,10 +551,10 @@ RSpec.describe Dry::AutoInject do
         it "works" do
           instance = child_class.new(:other)
 
-          expect(instance.other).to eq :other
-          expect(instance.one).to eq 1
-          expect(instance.two).to eq 2
-          expect(instance.three).to eq 3
+          expect(instance.send(:other)).to eq :other
+          expect(instance.send(:one)).to eq 1
+          expect(instance.send(:two)).to eq 2
+          expect(instance.send(:three)).to eq 3
         end
       end
     end

--- a/spec/integration/args_injection_spec.rb
+++ b/spec/integration/args_injection_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "argument parameters" do
       it "works" do
         instance = including_class.new
 
-        expect(instance.one).to eq 1
+        expect(instance.send(:one)).to eq 1
         expect(instance.module_var).to eq "hi"
       end
     end

--- a/spec/integration/chaining_injectors_spec.rb
+++ b/spec/integration/chaining_injectors_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "chaining injectors" do
 
   it "supports chaining injectors" do
     object = class_with_inject.new
-    expect(object.one).to eq 1
-    expect(object.two).to eq 2
+    expect(object.send(:one)).to eq 1
+    expect(object.send(:two)).to eq 2
 
     object = class_with_inject.new(one: "one", two: "two")
-    expect(object.one).to eq "one"
-    expect(object.two).to eq "two"
+    expect(object.send(:one)).to eq "one"
+    expect(object.send(:two)).to eq "two"
   end
 end

--- a/spec/integration/hash/inheritance/existing_ivars_before_initialize_spec.rb
+++ b/spec/integration/hash/inheritance/existing_ivars_before_initialize_spec.rb
@@ -34,13 +34,13 @@ RSpec.describe "kwargs / inheritance / instance variables set before #initialize
 
   it "does not assign nil value from missing dependency arg to its instance variable if it is already defined" do
     child = child_class.new
-    expect(child.configuration).to eq "configuration"
-    expect(child.another_dep).to eq "another_dep"
+    expect(child.send(:configuration)).to eq "configuration"
+    expect(child.send(:another_dep)).to eq "another_dep"
   end
 
   it "does assign an explicitly provided non-nil dependency to iits instance variable, even if it is already defined" do
     child = child_class.new(configuration: "child configuration")
-    expect(child.configuration).to eq "child configuration"
-    expect(child.another_dep).to eq "another_dep"
+    expect(child.send(:configuration)).to eq "child configuration"
+    expect(child.send(:another_dep)).to eq "another_dep"
   end
 end

--- a/spec/integration/hash/inheritance/parent_class_injections_spec.rb
+++ b/spec/integration/hash/inheritance/parent_class_injections_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "hash / inheritance / parent class also auto-injecting" do
 
     specify "auto-injections from parent class are available in child class" do
       child = child_class.new
-      expect(child.one).to eq "dep 1"
-      expect(child.two).to eq "dep 2"
+      expect(child.send(:one)).to eq "dep 1"
+      expect(child.send(:two)).to eq "dep 2"
     end
   end
 
@@ -42,8 +42,8 @@ RSpec.describe "hash / inheritance / parent class also auto-injecting" do
 
     specify "the child class' injection is kept" do
       child = child_class.new
-      expect(child.one).to eq "dep 1"
-      expect(child.two).to eq "dep 2"
+      expect(child.send(:one)).to eq "dep 1"
+      expect(child.send(:two)).to eq "dep 2"
     end
   end
 
@@ -62,8 +62,8 @@ RSpec.describe "hash / inheritance / parent class also auto-injecting" do
 
     specify "the child class' injection is kept" do
       child = child_class.new
-      expect(child.one).to eq "dep 2"
-      expect(child.two).to eq "dep 2"
+      expect(child.send(:one)).to eq "dep 2"
+      expect(child.send(:two)).to eq "dep 2"
     end
   end
 end

--- a/spec/integration/inheritance_spec.rb
+++ b/spec/integration/inheritance_spec.rb
@@ -45,13 +45,13 @@ RSpec.describe "Inheritance" do
 
     it "uses the dependencies from each of the containers" do
       instance = Test::Two.new
-      expect(instance.one).to eq "hi from one"
-      expect(instance.two).to eq "hi from two"
+      expect(instance.send(:one)).to eq "hi from one"
+      expect(instance.send(:two)).to eq "hi from two"
     end
 
     it "allows either dependency to be overridden" do
-      expect(Test::Two.new(one: "manual one").one).to eq "manual one"
-      expect(Test::Two.new(two: "manual two").two).to eq "manual two"
+      expect(Test::Two.new(one: "manual one").send(:one)).to eq "manual one"
+      expect(Test::Two.new(two: "manual two").send(:two)).to eq "manual two"
     end
   end
 end

--- a/spec/integration/kwargs/inheritance/existing_ivars_before_initialize_spec.rb
+++ b/spec/integration/kwargs/inheritance/existing_ivars_before_initialize_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe "kwargs / inheritance / instance variables set before #initialize
 
   it "does not assign nil value from missing dependency arg to its instance variable if it is already defined" do
     child = child_class.new
-    expect(child.configuration).to eq "configuration"
-    expect(child.another_dep).to eq "another_dep"
+    expect(child.send(:configuration)).to eq "configuration"
+    expect(child.send(:another_dep)).to eq "another_dep"
   end
 
   it "does assign an explicitly provided non-nil dependency to iits instance variable, even if it is already defined" do
     child = child_class.new(configuration: "child configuration")
-    expect(child.configuration).to eq "child configuration"
-    expect(child.another_dep).to eq "another_dep"
+    expect(child.send(:configuration)).to eq "child configuration"
+    expect(child.send(:another_dep)).to eq "another_dep"
   end
 end

--- a/spec/integration/kwargs/inheritance/parent_class_injections_spec.rb
+++ b/spec/integration/kwargs/inheritance/parent_class_injections_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe "kwargs / inheritance / parent class also auto-injecting" do
 
     specify "auto-injections from parent class are available in child class" do
       child = child_class.new
-      expect(child.one).to eq "dep 1"
-      expect(child.two).to eq "dep 2"
+      expect(child.send(:one)).to eq "dep 1"
+      expect(child.send(:two)).to eq "dep 2"
     end
   end
 
@@ -42,8 +42,8 @@ RSpec.describe "kwargs / inheritance / parent class also auto-injecting" do
 
     specify "the child class' injection is kept" do
       child = child_class.new
-      expect(child.one).to eq "dep 1"
-      expect(child.two).to eq "dep 2"
+      expect(child.send(:one)).to eq "dep 1"
+      expect(child.send(:two)).to eq "dep 2"
     end
   end
 
@@ -62,8 +62,8 @@ RSpec.describe "kwargs / inheritance / parent class also auto-injecting" do
 
     specify "the child class' injection is kept" do
       child = child_class.new
-      expect(child.one).to eq "dep 2"
-      expect(child.two).to eq "dep 2"
+      expect(child.send(:one)).to eq "dep 2"
+      expect(child.send(:two)).to eq "dep 2"
     end
   end
 
@@ -93,7 +93,7 @@ RSpec.describe "kwargs / inheritance / parent class also auto-injecting" do
 
     it "passes deps to the base constructor" do
       child = child_class.new
-      expect(child).to have_attributes(one: "dep 1")
+      expect(child.send(:one)).to eq "dep 1"
     end
   end
 end

--- a/spec/integration/kwargs/super_initialize_spec.rb
+++ b/spec/integration/kwargs/super_initialize_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe "kwargs / super #initialize method" do
     it "passes non-dependency keyword args to the super method" do
       instance = child_class.new(data: "data")
 
-      expect(instance.data).to eq "data"
-      expect(instance.one).to eq "dep 1"
+      expect(instance.send(:data)).to eq "data"
+      expect(instance.send(:one)).to eq "dep 1"
     end
   end
 
@@ -101,7 +101,7 @@ RSpec.describe "kwargs / super #initialize method" do
     it "passes dependencies assuming the parent class can take them" do
       instance = child_class.new
 
-      expect(instance.one).to eq "dep 1"
+      expect(instance.send(:one)).to eq "dep 1"
       expect(instance.dep).to eq "dep 1"
       expect(instance.args).to eq [one: "dep 1"]
     end
@@ -129,7 +129,7 @@ RSpec.describe "kwargs / super #initialize method" do
     it "doesn't pass deps if the final constructor will choke on them" do
       instance = child_class.new
 
-      expect(instance.one).to eq "dep 1"
+      expect(instance.send(:one)).to eq "dep 1"
     end
 
     context "with keywords" do
@@ -148,7 +148,7 @@ RSpec.describe "kwargs / super #initialize method" do
       it "doesn't pass deps if the final constructor will choke on them" do
         instance = child_class.new
 
-        expect(instance.one).to eq "dep 1"
+        expect(instance.send(:one)).to eq "dep 1"
       end
     end
 
@@ -168,7 +168,7 @@ RSpec.describe "kwargs / super #initialize method" do
       it "doesn't pass deps if the final constructor will choke on them" do
         instance = child_class.new
 
-        expect(instance.one).to eq "dep 1"
+        expect(instance.send(:one)).to eq "dep 1"
       end
     end
   end

--- a/spec/integration/kwargs_spec.rb
+++ b/spec/integration/kwargs_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "kwargs" do
       include Test::AutoInject[:one]
     end
 
-    expect(obj.new.one).to eq "dep 1"
-    expect(obj.new(one: false).one).to be false
-    expect(obj.new(one: nil).one).to be nil
+    expect(obj.new.send(:one)).to eq "dep 1"
+    expect(obj.new(one: false).send(:one)).to be false
+    expect(obj.new(one: nil).send(:one)).to be nil
   end
 
   it "forwards the block to the constructor" do
@@ -31,8 +31,19 @@ RSpec.describe "kwargs" do
 
     block = -> {}
 
-    expect(klass.new).to have_attributes(one: "dep 1", block: nil)
-    expect(klass.new(&block)).to have_attributes(one: "dep 1", block: block)
-    expect(klass.new(one: nil, &block)).to have_attributes(one: nil, block: block)
+    klass.new.tap do |obj|
+      expect(obj.send(:one)).to eq "dep 1"
+      expect(obj.block).to be nil
+    end
+
+    klass.new(&block).tap do |obj|
+      expect(obj.send(:one)).to eq "dep 1"
+      expect(obj.block).to eq block
+    end
+
+    klass.new(one: nil, &block).tap do |obj|
+      expect(obj.send(:one)).to be nil
+      expect(obj.block).to eq block
+    end
   end
 end

--- a/spec/integration/reader_visibility_spec.rb
+++ b/spec/integration/reader_visibility_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe "Reader visibility" do
+  shared_examples "private readers" do
+    before do
+      module Test
+        AutoInject = Dry::AutoInject(one: "dep 1")
+      end
+    end
+
+    it "creates private readers by default" do
+      strategy = self.strategy
+
+      object = Class.new {
+        include Test::AutoInject.send(strategy)[:one]
+      }.new
+
+      expect(object).not_to respond_to(:one)
+      expect(object.send(:one)).to eq "dep 1"
+    end
+
+    it "can have its readers made public" do
+      strategy = self.strategy
+
+      object = Class.new {
+        include Test::AutoInject.send(strategy)[:one]
+        public :one
+      }.new
+
+      expect(object).to respond_to(:one)
+      expect(object.one).to eq "dep 1"
+    end
+  end
+
+  describe "kwargs" do
+    let(:strategy) { :kwargs }
+    it_behaves_like "private readers"
+  end
+
+  describe "hash" do
+    let(:strategy) { :hash }
+    it_behaves_like "private readers"
+  end
+
+  describe "args" do
+    let(:strategy) { :args }
+    it_behaves_like "private readers"
+  end
+end


### PR DESCRIPTION
This improves encapsulation, and is still easy to opt out of by using the `public` method for whichever dependencies you want to make public, e.g.

```ruby
class MyClass
  include MyInjector[:dep_a, :dep_b]

  public :dep_a
end
```

This is a breaking change, and I propose we could release it as 1.0.0.beta1 if we want to shield existing users from unwanted churn.

Plus, I'm not sure if there's anything else we really need before we can ship 1.0.0 of auto_inject?