### PR TITLE
Update passthrough parameters list to support ruby 3.2

### DIFF
--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -6,7 +6,12 @@ module Dry
   module AutoInject
     # @api private
     class MethodParameters
-      PASS_THROUGH = [[%i[rest]], [%i[rest], %i[keyrest]]].freeze
+      PASS_THROUGH = [
+        [%i[rest]],
+        [%i[rest], %i[keyrest]],
+        [%i[rest *]],
+        [%i[rest *], %i[keyrest **]]
+      ].freeze
 
       def self.of(obj, name)
         Enumerator.new do |y|

--- a/spec/unit/method_parameters_spec.rb
+++ b/spec/unit/method_parameters_spec.rb
@@ -45,7 +45,11 @@ RSpec.describe Dry::AutoInject::MethodParameters do
       all_parameters = parameters.of(klass, :initialize).to_a
 
       expect(all_parameters.size).to eq 2
-      expect(all_parameters[0].parameters).to eql([[:rest]])
+      if RUBY_VERSION >= "3.2"
+        expect(all_parameters[0].parameters).to eql([[:rest, :*]])
+      else
+        expect(all_parameters[0].parameters).to eql([[:rest]])
+      end
       expect(all_parameters[1]).to be_empty
     end
   end


### PR DESCRIPTION
`Method#parameters` returns different result for `*` and `**` from ruby 3.2, so we need to update the constant to support them.