### PR TITLE
Update github_org in repo-sync.yml

### DIFF
--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -1,7 +1,7 @@
 name:
   gem: dry-auto_inject
   constant: Dry::AutoInject
-github_org: dry
+github_org: dry-rb
 gemspec:
   authors: ["Hanakai team"]
   email: ["info@hanakai.org"]


### PR DESCRIPTION
The previous `github_org` was https://github.com/dry which is markedly different from https://github.com/dry-rb.

This resulted in the repo sync steps to generate invalid URLs, e.g. in 36a9d8796da9d9f37db214da1fea210e63890f41