### PR TITLE
Remove obsolete parameter patterns

### DIFF
--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -4,13 +4,6 @@ module Dry
   module AutoInject
     # @api private
     class MethodParameters
-      PASS_THROUGH = [
-        [%i[rest]],
-        [%i[rest], %i[keyrest]],
-        [%i[rest *]],
-        [%i[rest *], %i[keyrest **]]
-      ].freeze
-
       def self.of(obj, name)
         ::Enumerator.new do |y|
           begin
@@ -59,7 +52,13 @@ module Dry
 
       def length = parameters.length
 
-      def pass_through? = PASS_THROUGH.include?(parameters)
+      def pass_through?
+        return false if parameters.empty?
+
+        parameters.all? do |param|
+          param in [:rest, :*] | [:keyrest, :**]
+        end
+      end
 
       EMPTY = new([])
     end

--- a/spec/unit/method_parameters_spec.rb
+++ b/spec/unit/method_parameters_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Dry::AutoInject::MethodParameters do
     it "lists methods defined in mixins" do
       klass = Class.new {
         include Module.new {
-          def initialize(*)
+          def initialize(*, **)
             super
           end
         }
@@ -45,11 +45,7 @@ RSpec.describe Dry::AutoInject::MethodParameters do
       all_parameters = parameters.of(klass, :initialize).to_a
 
       expect(all_parameters.size).to eq 2
-      if RUBY_VERSION >= "3.2"
-        expect(all_parameters[0].parameters).to eql([[:rest, :*]])
-      else
-        expect(all_parameters[0].parameters).to eql([[:rest]])
-      end
+      expect(all_parameters[0].parameters).to eql([[:rest, :*], [:keyrest, :**]])
       expect(all_parameters[1]).to be_empty
     end
   end


### PR DESCRIPTION
Now that 3.2 is the minimum Ruby version, we don't need to account for the different output from Method#parameters.