### PR TITLE
Add dependency order cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ## [Unreleased]
 
+### Added
+
+- Ship a `DryAutoInject/DependencyOrder` rubocop cop that enforces a configurable
+  order for dependencies inside `Import[...]` calls. Non-aliased deps are
+  emitted first, then aliased ones; within each section, deps are grouped by
+  the configured `Order` patterns and sorted alphabetically inside a group.
+  Supported pattern forms: `'*'` (catch-all, at most one and implicitly
+  appended), `'prefix.*'`, `/regex/flags`, or an exact path. The cop also
+  autocorrects.
+
+  Enable it from your `.rubocop.yml` using RuboCop's plugin system
+  (requires RuboCop 1.72+):
+
+  ```yaml
+  plugins:
+    - dry-auto_inject:
+        require_path: rubocop/dry_auto_inject
+
+  DryAutoInject/DependencyOrder:
+    Enabled: true
+    InjectorModules:  # Default is [Import, *::Import, Deps, *::Deps]
+      - Deps          # exact constant
+      - "*::Deps"     # match any namespace ending in `::Deps`
+    Order:
+      - "web.*"
+      - "*"
+      - "core.*"
+  ```
+
 ### Changed
 
 - Update minimum Ruby version to 3.2 (@timriley)

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,11 @@
+DryAutoInject/DependencyOrder:
+  Description: 'Enforces a configurable order for dry-auto_inject `Import[...]` dependencies.'
+  Enabled: true
+  VersionAdded: '1.2'
+  InjectorModules:
+    - 'Import'
+    - '*::Import'
+    - 'Deps'
+    - '*::Deps'
+  Order:
+    - '*'

--- a/dry-auto_inject.gemspec
+++ b/dry-auto_inject.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Container-agnostic automatic constructor injection"
   spec.description   = spec.summary
   spec.homepage      = "https://dry-rb.org/gems/dry-auto_inject"
-  spec.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "dry-auto_inject.gemspec", "lib/**/*"]
+  spec.files         = Dir["CHANGELOG.md", "LICENSE", "README.md", "dry-auto_inject.gemspec", "config/**/*", "lib/**/*"]
   spec.bindir        = "exe"
   spec.executables   = Dir["exe/*"].map { |f| File.basename(f) }
   spec.require_paths = ["lib"]
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"]   = "https://github.com/dry-rb/dry-auto_inject"
   spec.metadata["bug_tracker_uri"]   = "https://github.com/dry-rb/dry-auto_inject/issues"
   spec.metadata["funding_uri"]       = "https://github.com/sponsors/hanami"
+  spec.metadata["default_lint_roller_plugin"] = "RuboCop::DryAutoInject::Plugin"
 
   spec.required_ruby_version = ">= 3.3"
 

--- a/lib/dry/auto_inject.rb
+++ b/lib/dry/auto_inject.rb
@@ -13,7 +13,8 @@ module Dry
         loader.push_dir(root)
         loader.ignore(
           "#{root}/dry-auto_inject.rb",
-          "#{root}/dry/auto_inject/version.rb"
+          "#{root}/dry/auto_inject/version.rb",
+          "#{root}/rubocop"
         )
       end
     end

--- a/lib/dry/auto_inject/version.rb
+++ b/lib/dry/auto_inject/version.rb
@@ -2,6 +2,6 @@
 
 module Dry
   module AutoInject
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/rubocop/cop/dry_auto_inject/dependency_order.rb
+++ b/lib/rubocop/cop/dry_auto_inject/dependency_order.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require_relative "mixin"
+
+module RuboCop
+  module Cop
+    module DryAutoInject
+      # Enforces a configurable order for dry-auto_inject `Import[...]` deps.
+      #
+      # Non-aliased deps are emitted first, then aliased deps. Within each
+      # section, deps are grouped by matching the configured `Order` patterns
+      # and sorted alphabetically inside a group. Each pattern can be:
+      #
+      #   - `'*'`              — catch-all (at most one; implicitly appended)
+      #   - `'prefix.*'`       — prefix wildcard (matches `prefix` and `prefix.*`)
+      #   - `'/regex/flags'`   — regex matched against the dep path
+      #   - otherwise          — exact path match
+      #
+      # If `Order` is empty or omits `'*'`, a catch-all `'*'` group is appended
+      # implicitly so unmatched deps still have a home.
+      #
+      # Specific patterns take priority over the `*` catch-all regardless of
+      # their position in `Order`.
+      #
+      # @example Order: ['web.*', '*', 'core.*']
+      #   # bad
+      #   include Import[
+      #     'core.db',
+      #     'web.router',
+      #   ]
+      #
+      #   # good
+      #   include Import[
+      #     'web.router',
+      #     'core.db',
+      #   ]
+      #
+      # @example Order: ['/\A[^.]+\z/', '*']  — group dotless deps first
+      #   include Import[
+      #     'logger',
+      #     'core.db',
+      #   ]
+      class DependencyOrder < Base
+        extend AutoCorrector
+        include Mixin
+
+        MSG = "Dependencies are not in the configured order."
+
+        def initialize(config = nil, options = nil)
+          super
+          @parsed_order = build_parsed_order
+        end
+
+        def on_send(node)
+          return unless injector_call?(node)
+
+          deps = parse_injector_deps(node)
+          return if deps.nil?
+
+          order = parsed_order
+          current = deps[:non_aliased] + deps[:aliased]
+          sorted = [deps[:non_aliased], deps[:aliased]].flat_map { |group|
+            group_and_sort(group, order) { |d| d[:path] }
+          }
+
+          return if current == sorted
+
+          add_offense(node, message: MSG) do |corrector|
+            replace_injector_content(corrector, node, sorted)
+          end
+        end
+
+        private
+
+        attr_reader :parsed_order
+
+        def build_parsed_order
+          raw = Array(cop_config["Order"]).dup
+
+          if raw.count("*") > 1
+            raise "#{self.class.badge}: `Order` may contain at most one '*' entry " \
+                  "(got #{raw.inspect})"
+          end
+
+          raw << "*" unless raw.include?("*")
+          raw.each { |pat| validate_regex_pattern!(pat) if pat.start_with?("/") }
+          raw
+        end
+
+        def validate_regex_pattern!(pat)
+          return if parse_regex_entry(pat)
+
+          raise "#{self.class.badge}: invalid regex in `Order` entry #{pat.inspect}"
+        end
+
+        def group_and_sort(deps, order, &)
+          groups = ::Hash.new { |h, k| h[k] = [] }
+
+          # Specific patterns take priority over the `*` catch-all regardless
+          # of their position in `Order`.
+          specific_patterns = order.reject { |p| p == "*" }
+
+          deps.each do |d|
+            pat = specific_patterns.find { |p| match_pattern?(d[:path], p) } || "*"
+            groups[pat] << d
+          end
+
+          order.flat_map { |p| groups[p].sort_by(&) }
+        end
+
+        def match_pattern?(path, pattern)
+          return true if pattern == "*"
+
+          if pattern.start_with?("/")
+            parse_regex_entry(pattern)&.match?(path)
+          elsif pattern.end_with?(".*")
+            prefix = pattern[...-2]
+            path == prefix || path.start_with?("#{prefix}.")
+          else
+            path == pattern
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/dry_auto_inject/mixin.rb
+++ b/lib/rubocop/cop/dry_auto_inject/mixin.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "dry/core"
+
+module RuboCop
+  module Cop
+    module DryAutoInject
+      # Shared helpers for cops that inspect `Import[...]`-style calls produced
+      # by dry-auto_inject.
+      module Mixin
+        include ::Dry::Core::Constants
+
+        private
+
+        def injector_call?(node)
+          return false unless node.send_type?
+          return false unless node.method?(:[])
+
+          receiver = node.receiver
+          return false unless receiver&.const_type?
+
+          match_injector_module?(receiver)
+        end
+
+        def match_injector_module?(const_node)
+          full = const_fullname(const_node)
+          clean = full.sub(/\A::/, "")
+
+          Array(cop_config["InjectorModules"]).any? do |entry|
+            match_injector_entry?(entry.to_s, full, clean)
+          end
+        end
+
+        # Entry formats:
+        #   - `/pattern/flags`    — regex literal, matched against `clean`
+        #   - `*::Name`           — last segment match with any prefix (incl. empty)
+        #   - otherwise           — exact match on the full or leading-`::`-stripped path
+        def match_injector_entry?(entry, full, clean)
+          if entry.start_with?("/")
+            regex = parse_regex_entry(entry)
+            return false unless regex
+
+            regex.match?(clean)
+          elsif entry.start_with?("*::")
+            suffix = entry[3..]
+            clean == suffix || clean.end_with?("::#{suffix}")
+          else
+            entry == full || entry == clean
+          end
+        end
+
+        # Returns a Regexp for a `/pattern/flags` literal, or nil if the
+        # string is not a regex literal or the pattern is invalid.
+        def parse_regex_entry(str)
+          m = str.match(%r{\A/(.*)/([imx]*)\z}m)
+          return nil unless m
+
+          opts = 0
+          opts |= ::Regexp::IGNORECASE if m[2].include?("i")
+          opts |= ::Regexp::MULTILINE if m[2].include?("m")
+          opts |= ::Regexp::EXTENDED if m[2].include?("x")
+          ::Regexp.new(m[1], opts)
+        rescue ::RegexpError
+          nil
+        end
+
+        def const_fullname(const_node)
+          parts = []
+          current = const_node
+
+          while current
+            if current.const_type?
+              parts.unshift(current.children[1].to_s)
+              current = current.children[0]
+            elsif current.cbase_type?
+              parts.unshift("")
+              current = nil
+            else
+              return ""
+            end
+          end
+
+          parts.join("::")
+        end
+
+        # Parses the arguments of an `Import[...]` call into a structured form.
+        # Returns nil if any argument is not a plain string or symbol-keyed/string-valued pair.
+        def parse_injector_deps(node)
+          args = node.arguments
+          return nil if args.empty?
+
+          hash_arg = args.last if args.last.hash_type?
+          string_nodes = hash_arg ? args[...-1] : args
+
+          non_aliased = parse_non_aliased_deps(string_nodes)
+          aliased = parse_aliased_deps(hash_arg)
+          return nil if non_aliased.nil? || aliased.nil?
+
+          {non_aliased:, aliased:}
+        end
+
+        def parse_non_aliased_deps(nodes)
+          return nil unless nodes.all?(&:str_type?)
+
+          nodes.map { |arg| {node: arg, alias: nil, path: arg.value} }
+        end
+
+        def parse_aliased_deps(hash_arg)
+          return EMPTY_ARRAY unless hash_arg
+          return nil unless hash_arg.pairs.all? { |p| p.key.sym_type? && p.value.str_type? }
+
+          hash_arg.pairs.map { |p| {node: p, alias: p.key.value.to_s, path: p.value.value} }
+        end
+
+        def format_dep(dep)
+          node = dep[:node]
+          if dep[:alias]
+            "#{dep[:alias]}: #{node.value.source}"
+          else
+            node.source
+          end
+        end
+
+        def line_indent_col(node)
+          line = node.source_range.source_line
+          line.index(/\S/) || node.source_range.column
+        end
+
+        def item_indent_spaces(node)
+          args = node.arguments
+
+          if args.any? && args.first.source_range.line > node.source_range.line
+            indent(args.first.source_range.column)
+          else
+            indent(line_indent_col(node) + 2)
+          end
+        end
+
+        def indent(width)
+          " " * width
+        end
+
+        def render_deps(node, deps)
+          if node.multiline?
+            inner_indent = item_indent_spaces(node)
+            close_indent = indent(line_indent_col(node))
+            lines = deps.map { |d| "#{inner_indent}#{format_dep(d)}," }
+            "\n#{lines.join("\n")}\n#{close_indent}"
+          else
+            deps.map { |d| format_dep(d) }.join(", ")
+          end
+        end
+
+        def replace_injector_content(corrector, node, deps)
+          selector = node.loc.selector
+          return unless selector&.source&.start_with?("[")
+
+          corrector.replace(selector.adjust(begin_pos: 1, end_pos: -1), render_deps(node, deps))
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/dry_auto_inject.rb
+++ b/lib/rubocop/dry_auto_inject.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative "dry_auto_inject/plugin"
+require_relative "cop/dry_auto_inject/dependency_order"

--- a/lib/rubocop/dry_auto_inject/plugin.rb
+++ b/lib/rubocop/dry_auto_inject/plugin.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "lint_roller"
+
+require "dry/auto_inject/version"
+
+module RuboCop
+  module DryAutoInject
+    class Plugin < ::LintRoller::Plugin
+      def about
+        ::LintRoller::About.new(
+          name: "dry-auto_inject",
+          version: ::Dry::AutoInject::VERSION,
+          homepage: "https://hanakai.org/learn/dry/dry-auto_inject",
+          description: "RuboCop cops for enforcing dry-auto_inject conventions."
+        )
+      end
+
+      def supported?(context)
+        context.engine == :rubocop
+      end
+
+      def rules(_context)
+        project_root = ::Pathname.new(__dir__).join("../../..")
+
+        ::LintRoller::Rules.new(
+          type: :path,
+          config_format: :rubocop,
+          value: project_root.join("config", "default.yml")
+        )
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/dry_auto_inject/dependency_order_spec.rb
+++ b/spec/rubocop/cop/dry_auto_inject/dependency_order_spec.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/rspec/support"
+require "rubocop/dry_auto_inject"
+
+RSpec.describe RuboCop::Cop::DryAutoInject::DependencyOrder do
+  include RuboCop::RSpec::ExpectOffense
+
+  let(:cop_config) do
+    {"InjectorModules" => ["Import"], "Order" => ["*"]}
+  end
+
+  let(:config) do
+    RuboCop::Config.new(
+      "DryAutoInject/DependencyOrder" => cop_config
+    )
+  end
+
+  subject(:cop) { described_class.new(config) }
+
+  context "when the call is not an Import" do
+    it "registers no offenses" do
+      expect_no_offenses(<<~RUBY)
+        Foo['b', 'a']
+      RUBY
+    end
+  end
+
+  context "when there is only one dep" do
+    it "registers no offenses" do
+      expect_no_offenses(<<~RUBY)
+        include Import['foo']
+      RUBY
+    end
+  end
+
+  context "when deps are already alphabetically sorted" do
+    it "registers no offenses" do
+      expect_no_offenses(<<~RUBY)
+        include Import['a.thing', 'b.other']
+      RUBY
+    end
+  end
+
+  context "when non-aliased deps need sorting" do
+    it "registers an offense and sorts alphabetically" do
+      expect_offense(<<~RUBY)
+        include Import['b.other', 'a.thing']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import['a.thing', 'b.other']
+      RUBY
+    end
+  end
+
+  context "when non-aliased deps are unsorted alongside aliased deps" do
+    it "sorts the non-aliased section and keeps aliased deps last" do
+      expect_offense(<<~RUBY)
+        include Import['b.other', 'a.thing', bar: 'ns.thing']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import['a.thing', 'b.other', bar: 'ns.thing']
+      RUBY
+    end
+  end
+
+  context "within a multiline Import block" do
+    it "preserves the multiline formatting" do
+      expect_offense(<<~RUBY)
+        class Foo
+          include Import[
+                  ^^^^^^^ Dependencies are not in the configured order.
+            'tracing.propagate_context',
+            'tracing.attributes_from_hash',
+            parse_json: 'json.parse',
+          ]
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo
+          include Import[
+            'tracing.attributes_from_hash',
+            'tracing.propagate_context',
+            parse_json: 'json.parse',
+          ]
+        end
+      RUBY
+    end
+  end
+
+  context "with a custom Order groups list" do
+    let(:cop_config) do
+      {"InjectorModules" => ["Import"], "Order" => ["web.*", "*", "core.*"]}
+    end
+
+    it "splits non-aliased deps into groups and sorts within each" do
+      expect_offense(<<~RUBY)
+        include Import['core.db', 'other.thing', 'web.router', 'core.cache', 'web.auth']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import['web.auth', 'web.router', 'other.thing', 'core.cache', 'core.db']
+      RUBY
+    end
+
+    it "also applies groups to aliased deps" do
+      expect_offense(<<~RUBY)
+        include Import[cache: 'core.cache', router: 'web.router', thing: 'other.thing']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import[router: 'web.router', thing: 'other.thing', cache: 'core.cache']
+      RUBY
+    end
+
+    it "sorts within an aliased group by path (container key), not by alias" do
+      expect_no_offenses(<<~RUBY)
+        include Import[zebra: 'web.aaa', alpha: 'web.zzz']
+      RUBY
+    end
+  end
+
+  context "when aliased deps within a group have the same prefix" do
+    it "sorts by path, not by alias" do
+      expect_offense(<<~RUBY)
+        include Import[alpha: 'ns.zzz', zebra: 'ns.aaa']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import[zebra: 'ns.aaa', alpha: 'ns.zzz']
+      RUBY
+    end
+  end
+
+  context "when Order has no `*`" do
+    let(:cop_config) do
+      {"InjectorModules" => ["Import"], "Order" => ["web.*"]}
+    end
+
+    it "implicitly appends `*` as the last group" do
+      expect_offense(<<~RUBY)
+        include Import['core.db', 'web.router']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import['web.router', 'core.db']
+      RUBY
+    end
+  end
+
+  context "with a regex Order entry" do
+    let(:cop_config) do
+      {"InjectorModules" => ["Import"], "Order" => ['/\A[^.]+\z/', "*"]}
+    end
+
+    it "puts deps matching the regex first" do
+      expect_offense(<<~RUBY)
+        include Import['core.db', 'logger', 'web.router', 'cache']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import['cache', 'logger', 'core.db', 'web.router']
+      RUBY
+    end
+
+    it "applies the regex group to aliased deps too" do
+      expect_offense(<<~RUBY)
+        include Import[db: 'core.db', log: 'logger']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import[log: 'logger', db: 'core.db']
+      RUBY
+    end
+  end
+
+  context "with a regex Order entry using flags" do
+    let(:cop_config) do
+      {"InjectorModules" => ["Import"], "Order" => ['/\AWEB\./i', "*"]}
+    end
+
+    it "honours regex flags" do
+      expect_offense(<<~RUBY)
+        include Import['core.db', 'web.router']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import['web.router', 'core.db']
+      RUBY
+    end
+  end
+
+  context "when Order has an invalid regex" do
+    let(:cop_config) do
+      {"InjectorModules" => ["Import"], "Order" => ["/[unclosed/"]}
+    end
+
+    it "raises a configuration error during construction" do
+      expect { described_class.new(config) }
+        .to raise_error(/invalid regex/)
+    end
+  end
+
+  context "when Order has a malformed regex literal" do
+    let(:cop_config) do
+      {"InjectorModules" => ["Import"], "Order" => ["/foo"]}
+    end
+
+    it "raises a configuration error during construction" do
+      expect { described_class.new(config) }
+        .to raise_error(/invalid regex/)
+    end
+  end
+
+  context "when Order contains more than one `*`" do
+    let(:cop_config) do
+      {"InjectorModules" => ["Import"], "Order" => ["*", "web.*", "*"]}
+    end
+
+    it "raises a configuration error during construction" do
+      expect { described_class.new(config) }
+        .to raise_error(/at most one '\*'/)
+    end
+  end
+
+  context "with a `*::Name` wildcard entry" do
+    let(:cop_config) do
+      {"InjectorModules" => ["*::Import"], "Order" => ["*"]}
+    end
+
+    it "matches any path ending in the given suffix" do
+      expect_offense(<<~RUBY)
+        include ::MyApp::SDK::Import['b', 'a']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include ::MyApp::SDK::Import['a', 'b']
+      RUBY
+    end
+  end
+
+  context "when `Import` is configured as a literal entry" do
+    it "does not match a namespaced constant" do
+      expect_no_offenses(<<~RUBY)
+        include ::MyApp::SDK::Import['b', 'a']
+      RUBY
+    end
+  end
+
+  context "when correcting deps that use varied quote styles" do
+    it "preserves double quotes on non-aliased deps" do
+      expect_offense(<<~RUBY)
+        include Import["b.other", "a.thing"]
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import["a.thing", "b.other"]
+      RUBY
+    end
+
+    it "preserves double quotes on aliased dep values" do
+      expect_offense(<<~RUBY)
+        include Import[alpha: "ns.zzz", zebra: "ns.aaa"]
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import[zebra: "ns.aaa", alpha: "ns.zzz"]
+      RUBY
+    end
+
+    it "preserves mixed quote styles per dep" do
+      expect_offense(<<~RUBY)
+        include Import["b.other", 'a.thing', y: "ns.zzz", x: 'ns.aaa']
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dependencies are not in the configured order.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        include Import['a.thing', "b.other", x: 'ns.aaa', y: "ns.zzz"]
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This adds a new opt-in rubocop cop, `DryAutoInject/DependencyOrder`, that enforces a configurable order for dependencies inside `Import[...]`/`Deps[...]` calls produced by dry-auto_inject. The cop autocorrects.

Within an `Import[...]` call, non-aliased deps are emitted first, then aliased deps. Each section is split into groups according to the configured `Order` patterns and sorted alphabetically inside a group. Supported pattern forms:

- `'*'` — catch-all (at most one; implicitly appended if not present)
- `'prefix.*'` — prefix wildcard (matches `prefix` and `prefix.*`)
- `'/regex/flags'` — regex matched against the dep path
- otherwise — exact path match

`InjectorModules` controls which constants the cop inspects. Entries can be:

- `Import` — exact constant
- `*::Import` — match any namespace ending in `::Import`
- `/regex/flags` — regex against the constant path

## Usage

In your `.rubocop.yml`:

```yaml
require:
  - rubocop/dry_auto_inject

DryAutoInject/DependencyOrder:
  Enabled: true
  InjectorModules:
    - Import
    - "*::Import"
  Order:
    - "web.*"
    - "*"
    - "core.*"

Given the config above:

# bad
include Import["core.db", "web.router"]

# good (autocorrected)
include Import["web.router", "core.db"]
