### PR TITLE
Prevent parent-class injection from discarding pass-through args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
       - "core.*"
   ```
 
+## Fixed
+
+- Ancestor parameter detection for smart kwarg forwarding is no longer obscured by injections in a parent class (@alassek in [#97](https://github.com/dry-rb/dry-auto_inject/pull/97))
+
 ### Changed
 
 - Update minimum Ruby version to 3.2 (@timriley)

--- a/lib/dry/auto_inject/method_parameters.rb
+++ b/lib/dry/auto_inject/method_parameters.rb
@@ -54,9 +54,19 @@ module Dry
 
       def pass_through?
         return false if parameters.empty?
+        return true if parameters.any? { |param| param in [:keyrest, :__auto_inject_kwargs__] }
 
         parameters.all? do |param|
-          param in [:rest, :*] | [:keyrest, :**]
+          case param
+          in [:rest, :*] | [:keyrest, :**]
+            true
+          in [:rest | :req | :opt | :keyrest | :keyreq | :key | :block, _]
+            false
+          in [:nokey]
+            false
+          else
+            true
+          end
         end
       end
 

--- a/lib/dry/auto_inject/strategies/kwargs.rb
+++ b/lib/dry/auto_inject/strategies/kwargs.rb
@@ -23,8 +23,10 @@ module Dry
 
         def define_initialize(klass)
           super_parameters = MethodParameters.of(klass, :initialize).each do |ps|
-            # Look upwards past `def foo(*)` and `def foo(...)` methods
-            # until we get an explicit list of parameters
+            # Look upwards past methods that only forward arguments, stopping at the
+            # first instance of explicit parameters. So `foo(**kwargs)` is
+            # skipped, but `foo(bar:, **kwargs)` is not. `foo(...)` is used by ROM as
+            # a delegation pattern, so it is not skipped.
             break ps unless ps.pass_through?
           end
 
@@ -37,15 +39,18 @@ module Dry
           self
         end
 
+        # rubocop:disable Lint/UnderscorePrefixedVariableName
         def define_initialize_with_keywords(super_parameters)
           assign_dependencies = method(:assign_dependencies)
           slice_kwargs = method(:slice_kwargs)
 
           instance_mod.class_exec do
-            define_method :initialize do |**kwargs, &block|
-              assign_dependencies.(kwargs, self)
+            # The choice of `__auto_inject_kwargs__` here is intentional, and used
+            # by MethodParameters#pass_through? to detect an injected initialize.
+            define_method :initialize do |**__auto_inject_kwargs__, &block|
+              assign_dependencies.(__auto_inject_kwargs__, self)
 
-              super_kwargs = slice_kwargs.(kwargs, super_parameters)
+              super_kwargs = slice_kwargs.(__auto_inject_kwargs__, super_parameters)
 
               if super_kwargs.any?
                 super(**super_kwargs, &block)
@@ -61,13 +66,13 @@ module Dry
           slice_kwargs = method(:slice_kwargs)
 
           instance_mod.class_exec do
-            define_method :initialize do |*args, **kwargs, &block|
-              assign_dependencies.(kwargs, self)
+            define_method :initialize do |*args, **__auto_inject_kwargs__, &block|
+              assign_dependencies.(__auto_inject_kwargs__, self)
 
               if super_parameters.splat?
-                super(*args, **kwargs, &block)
+                super(*args, **__auto_inject_kwargs__, &block)
               else
-                super_kwargs = slice_kwargs.(kwargs, super_parameters)
+                super_kwargs = slice_kwargs.(__auto_inject_kwargs__, super_parameters)
 
                 if super_kwargs.any?
                   super(*args, **super_kwargs, &block)
@@ -78,6 +83,7 @@ module Dry
             end
           end
         end
+        # rubocop:enable Lint/UnderscorePrefixedVariableName
 
         def assign_dependencies(kwargs, destination)
           dependency_map.names.each do |name|

--- a/spec/integration/kwargs/inheritance/parent_module_keyword_overlap_spec.rb
+++ b/spec/integration/kwargs/inheritance/parent_module_keyword_overlap_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe "kwargs / inheritance / parent module keyword overlapping injected dep" do
+  before do
+    module Test
+      AutoInject = Dry::AutoInject(one: "dep 1", view: "dep view")
+    end
+  end
+
+  let(:keyword_module) do
+    Module.new do
+      def initialize(view: nil, **kwargs)
+        @view = view
+        super(**kwargs)
+      end
+    end
+  end
+
+  describe "parent includes a module with an explicit keyword, then auto_inject" do
+    let(:parent_class) do
+      mod = keyword_module
+      Class.new do
+        include mod
+        include Test::AutoInject[:one]
+      end
+    end
+
+    let(:child_class) do
+      Class.new(parent_class) do
+        include Test::AutoInject[:view]
+      end
+    end
+
+    specify "injected dependency matching the module's keyword is preserved" do
+      instance = child_class.new
+      expect(instance.view).to eq "dep view"
+    end
+
+    specify "dependencies from the parent class are also available" do
+      instance = child_class.new
+      expect(instance.one).to eq "dep 1"
+    end
+  end
+
+  describe "parent auto_injects, then includes the keyword module (reversed order)" do
+    let(:parent_class) do
+      mod = keyword_module
+      Class.new do
+        include Test::AutoInject[:one]
+        include mod
+      end
+    end
+
+    let(:child_class) do
+      Class.new(parent_class) do
+        include Test::AutoInject[:view]
+      end
+    end
+
+    specify "injected dependency matching the module's keyword is preserved" do
+      instance = child_class.new
+      expect(instance.one).to eq "dep 1"
+      expect(instance.view).to eq "dep view"
+    end
+  end
+
+  describe "module uses a required keyword" do
+    let(:keyword_module) do
+      Module.new do
+        def initialize(view:, **kwargs)
+          @view = view
+          super(**kwargs)
+        end
+      end
+    end
+
+    let(:parent_class) do
+      mod = keyword_module
+      Class.new do
+        include mod
+        include Test::AutoInject[:one]
+      end
+    end
+
+    let(:child_class) do
+      Class.new(parent_class) do
+        include Test::AutoInject[:view]
+      end
+    end
+
+    specify "injected dependency matching the module's required keyword is preserved" do
+      instance = child_class.new
+      expect(instance.view).to eq "dep view"
+    end
+  end
+end

--- a/spec/unit/method_parameters_spec.rb
+++ b/spec/unit/method_parameters_spec.rb
@@ -49,4 +49,41 @@ RSpec.describe Dry::AutoInject::MethodParameters do
       expect(all_parameters[1]).to be_empty
     end
   end
+
+  describe "#pass_through?" do
+    it "returns true for anonymous splat (*, **)" do
+      params = described_class.new([[:rest, :*], [:keyrest, :**]])
+      expect(params.pass_through?).to be true
+    end
+
+    it "returns false for forwarding (...) due to named block parameter" do
+      params = described_class.new([[:rest, :*], [:keyrest, :**], [:block, :&]])
+      expect(params.pass_through?).to be false
+    end
+
+    it "returns true for unnamed parameters" do
+      params = described_class.new([[:rest], [:keyrest]])
+      expect(params.pass_through?).to be true
+    end
+
+    it "returns true for injected kwargs" do
+      params = described_class.new([[:keyrest, :__auto_inject_kwargs__]])
+      expect(params.pass_through?).to be true
+    end
+
+    it "returns false for empty parameters" do
+      params = described_class.new([])
+      expect(params.pass_through?).to be false
+    end
+
+    it "returns false for named parameters" do
+      params = described_class.new([[:req, :a], [:keyreq, :b]])
+      expect(params.pass_through?).to be false
+    end
+
+    it "returns false for **nil (nokey)" do
+      params = described_class.new([[:nokey]])
+      expect(params.pass_through?).to be false
+    end
+  end
 end


### PR DESCRIPTION
This was a tortuous process to get here, shoutout to DeepSeek V4 for essentially brute-forcing the logical variations on this. I probably would've given up on this otherwise.

This is a bug surfaced by Hanami's View integration. The Action initializer looks like this:

```ruby
def initialize(view: nil, view_context_class: nil, rack_monitor: nil, routes: nil, **kwargs)
  @view = view
  @view_context_class = view_context_class
  @routes = routes
  @rack_monitor = rack_monitor

  super(**kwargs)
end
```

So the `:view` kwarg accepts the view instance and sets the ivar. This is passed in implicitly based on naming convention, but in situations where users want to use a specific view instead, we encourage using Dry::AutoInject to pass it explicitly:

```ruby
module App
  module Actions
    class MyAction < Action
      include Deps[view: "custom.view"]
    end
  end
end
```

If the final Action class is the only location where a Deps module is included, there is no problem. But what if you happened to also include a dependency in the parent class?

```ruby
module App
  class Action < Hanami::Action
    include Deps["logger"]
  end
end
```

Now what takes place is that the second `include Deps` calls `MethodParameters.of(klass, :initialize)` and walks the ancestor chain until it encounters the first non-passthrough method to determine which args it needs to send into `super`.

Because:

1. `initialize` methods added by Dry::AutoInject are _not_ interpreted as passthrough
2. `:view` is present in the dependency_map of the child class

Then the `:view` kwarg gets discarded when passing args to `super`. This causes the parent `Action` class to use the default value, and since that `initialize` executes _after_ the child's injected `initialize`, the custom view gets overridden to `nil`.