### PR TITLE
Fix plugin not loading cop classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Break Versioning](https://www.taoensso.com/break-versioning).
 
+## [1.2.1] - 2026-05-26
+
+### Fixed
+
+- Load cop classes when the RuboCop plugin is required, so offenses are
+  actually reported (@flash-gordon in #100)
+
+[1.2.1]: https://github.com/dry-rb/dry-auto_inject/compare/v1.2.0...v1.2.1
+
 ## [1.2.0] - 2026-05-19
 
 ### Added

--- a/lib/dry/auto_inject/version.rb
+++ b/lib/dry/auto_inject/version.rb
@@ -2,6 +2,6 @@
 
 module Dry
   module AutoInject
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end

--- a/lib/rubocop/dry_auto_inject/plugin.rb
+++ b/lib/rubocop/dry_auto_inject/plugin.rb
@@ -3,6 +3,8 @@
 require "lint_roller"
 
 require "dry/auto_inject/version"
+require_relative "../cop/dry_auto_inject/dependency_order"
+require_relative "../cop/dry_auto_inject/redundant_alias"
 
 module RuboCop
   module DryAutoInject

--- a/spec/rubocop/dry_auto_inject/plugin_spec.rb
+++ b/spec/rubocop/dry_auto_inject/plugin_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/dry_auto_inject/plugin"
+
+RSpec.describe RuboCop::DryAutoInject::Plugin do
+  subject(:plugin) { described_class.new }
+
+  describe "#rules" do
+    it "loads cop classes into the registry" do
+      plugin.rules(nil)
+
+      registry = RuboCop::Cop::Registry.global
+      cops = registry.select { |c| c.badge.department_name == "DryAutoInject" }
+
+      expect(cops.map { |c| c.badge.to_s }).to contain_exactly(
+        "DryAutoInject/DependencyOrder",
+        "DryAutoInject/RedundantAlias"
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- RuboCop's plugin system requires `rubocop/dry_auto_inject/plugin` directly (derived from the gemspec `default_lint_roller_plugin` metadata), bypassing `rubocop/dry_auto_inject` which loads the cop classes. The config was registered but cops were never loaded into the registry, so no offenses were reported.
- Added cop `require_relative` calls to `plugin.rb` so cops are loaded regardless of the entry point.
- Added a spec that verifies cop classes are registered when only `plugin.rb` is required.

## Test plan

- [x] `bundle exec rspec spec/rubocop/` passes (42 examples, 0 failures)
- [x] Verified in a downstream project that `rubocop --show-cops` now lists `DryAutoInject/DependencyOrder` and `DryAutoInject/RedundantAlias`
- [x] Verified the cop detects and autocorrects dependency ordering violations